### PR TITLE
make code robust to NaNs

### DIFF
--- a/meteor/diffmaps.py
+++ b/meteor/diffmaps.py
@@ -52,7 +52,7 @@ def compute_difference_map(derivative: Map, native: Map) -> Map:
     _assert_is_map(derivative, require_uncertainties=False)
     _assert_is_map(native, require_uncertainties=False)
 
-    derivative, native = filter_common_indices(derivative, native)  # type: ignore[assignment]
+    derivative, native = filter_common_indices(derivative, native)
 
     delta_complex = derivative.complex_amplitudes - native.complex_amplitudes
     delta = Map.from_structurefactor(delta_complex, index=native.index)

--- a/meteor/iterative.py
+++ b/meteor/iterative.py
@@ -214,8 +214,7 @@ def iterative_tv_phase_retrieval(  # noqa: PLR0913
         the tv_weight used, the negentropy (after the TV step), and the average phase change in
         degrees.
     """
-    # hotfix #52
-    initial_derivative, native = filter_common_indices(initial_derivative, native)  # type: ignore[assignment]
+    initial_derivative, native = filter_common_indices(initial_derivative, native)
 
     # clean TV denoising interface that is crystallographically intelligent
     # maintains state for the HKL index, spacegroup, and cell information

--- a/meteor/rsmap.py
+++ b/meteor/rsmap.py
@@ -193,12 +193,12 @@ class Map(rs.DataSet):
             raise MapMutabilityError(msg)
 
     @overload
-    def drop(self, labels: Any = None, *, inplace: Literal[True]) -> None: ...
+    def drop(self, labels: Any, *, inplace: Literal[True]) -> None: ...
 
     @overload
-    def drop(self, labels: Any = None, *, inplace: Literal[False]) -> Map: ...
+    def drop(self, labels: Any, *, inplace: Literal[False]) -> Map: ...
 
-    def drop(self, labels: Any = None, *, inplace: bool = False) -> None | Map:
+    def drop(self, labels: Any, *, inplace: bool = False) -> None | Map:
         return super().drop(labels=labels, axis="index", columns=None, inplace=inplace)
 
     def get_hkls(self) -> np.ndarray:

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -85,6 +85,9 @@ def compute_scale_factors(
     ----------
     [1] SCALEIT https://www.ccp4.ac.uk/html/scaleit.html
     """
+    reference_values.dropna(axis="index", how="any", inplace=True)
+    values_to_scale.dropna(axis="index", how="any", inplace=True)
+
     common_miller_indices: pd.Index = reference_values.index.intersection(values_to_scale.index)
     common_reference_values: np.ndarray = reference_values.loc[common_miller_indices].to_numpy()
     common_values_to_scale: np.ndarray = values_to_scale.loc[common_miller_indices].to_numpy()

--- a/meteor/scripts/common.py
+++ b/meteor/scripts/common.py
@@ -184,7 +184,6 @@ class DiffmapArgParser(argparse.ArgumentParser):
         )
 
         mtz = rs.read_mtz(str(mtz_file))
-        mtz.dropna(axis="index", how="any", inplace=True)  # hotfix #52
 
         if PHASE_COLUMN_NAME in mtz.columns:
             log.warning(
@@ -207,6 +206,8 @@ class DiffmapArgParser(argparse.ArgumentParser):
             else uncertainty_column
         )
         log.info("  uncertainties", sought=uncertainty_column, found=found_uncertainty_column)
+
+        mtz.dropna(axis="index", how="any", subset=found_amplitude_column, inplace=True)
 
         return Map(
             mtz,

--- a/meteor/utils.py
+++ b/meteor/utils.py
@@ -5,14 +5,15 @@ from typing import Literal, overload
 import gemmi
 import numpy as np
 import reciprocalspaceship as rs
-from pandas import DataFrame, Index
+from pandas import Index
+from reciprocalspaceship import DataSet
 from reciprocalspaceship.utils import canonicalize_phases
 
 
 class ShapeMismatchError(Exception): ...
 
 
-def filter_common_indices(df1: DataFrame, df2: DataFrame) -> tuple[DataFrame, DataFrame]:
+def filter_common_indices(df1: DataSet, df2: DataSet) -> tuple[DataSet, DataSet]:
     common_indices = df1.index.intersection(df2.index)
     df1_common = df1.loc[common_indices].copy()
     df2_common = df2.loc[common_indices].copy()

--- a/test/unit/scripts/test_common.py
+++ b/test/unit/scripts/test_common.py
@@ -25,10 +25,12 @@ def mocked_read_mtz(dummy_filename: str) -> rs.DataSet:
     # if read_mtz gets a Path, it freaks out; requires str
     assert isinstance(dummy_filename, str)
 
-    index = pd.MultiIndex.from_arrays([[1, 1, 5], [1, 2, 5], [1, 3, 5]], names=("H", "K", "L"))
+    index = pd.MultiIndex.from_arrays(
+        [[1, 1, 5, 6], [1, 2, 5, 6], [1, 3, 5, 6]], names=("H", "K", "L")
+    )
     data = {
-        "F": np.array([2.0, 3.0, 1.0]),
-        "SIGF": np.array([0.5, 0.5, 1.0]),
+        "F": np.array([2.0, 3.0, 1.0, np.nan]),
+        "SIGF": np.array([0.5, 0.5, 1.0, np.nan]),
     }
     return rs.DataSet(data, index=index).infer_mtz_dtypes()
 

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -89,6 +89,30 @@ def test_complex_derivative_from_iterative_tv() -> None:
     assert 1.05 * noisy_error < denoised_error
 
 
+def test_iterative_tv_different_indices(noise_free_map: Map, very_noisy_map: Map) -> None:
+    # regression test to make sure we can accept maps with different indices
+    labels = pd.MultiIndex.from_arrays(
+        [
+            (1, 2),
+        ]
+        * 3,
+        names=("H", "K", "L"),
+    )
+    n = len(very_noisy_map)
+    very_noisy_map.drop(labels, inplace=True)
+    assert len(very_noisy_map) == n - 2
+
+    denoised_map, metadata = iterative_tv_phase_retrieval(
+        very_noisy_map,
+        noise_free_map,
+        tv_weights_to_scan=[0.1],
+        max_iterations=100,
+        convergence_tolerance=0.01,
+    )
+    assert isinstance(metadata, pd.DataFrame)
+    assert isinstance(denoised_map, Map)
+
+
 def test_iterative_tv(noise_free_map: Map, very_noisy_map: Map) -> None:
     # the test case is the denoising of a difference: between a noisy map and its noise-free origin
     # such a diffmap is ideally totally flat, so should have very low TV

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -54,6 +54,17 @@ def test_compute_scale_factors_shuffle_indices(miller_dataseries: rs.DataSeries)
     assert (scale_factors == 1.0).all()
 
 
+def test_compute_scale_factors_nans(miller_dataseries: rs.DataSeries) -> None:
+    with_nans = miller_dataseries.copy()
+    with_nans.iloc[0] = np.nan
+    miller_dataseries.iloc[1] = np.nan
+    scale_factors = scale.compute_scale_factors(
+        reference_values=miller_dataseries,
+        values_to_scale=with_nans,
+    )
+    assert (scale_factors == 1.0).all()
+
+
 def test_compute_scale_factors_scalar(miller_dataseries: rs.DataSeries) -> None:
     multiple = 2.0
     doubled_miller_dataseries = miller_dataseries / multiple

--- a/test/unit/test_tv.py
+++ b/test/unit/test_tv.py
@@ -81,6 +81,16 @@ def test_tv_denoise_zero_weight(random_difference_map: Map) -> None:
     pd.testing.assert_frame_equal(random_difference_map, output, atol=1e-2, rtol=1e-2)
 
 
+def test_tv_denoise_nan_input(random_difference_map: Map) -> None:
+    weight = 0.0
+    random_difference_map.iloc[0] = np.nan
+    _ = tv.tv_denoise_difference_map(
+        random_difference_map,
+        weights_to_scan=[weight],
+        full_output=False,
+    )
+
+
 @pytest.mark.parametrize("weights_to_scan", [None, DEFAULT_WEIGHTS_TO_SCAN])
 def test_tv_denoise_map(
     weights_to_scan: None | Sequence[float],


### PR DESCRIPTION
We had a user who provided an MTZ with NaNs, and this broke the scaling process. A hotfix was pushed, but it wasn't ideal. This makes the fix better, and adds a few regression tests.

Addresses #52.