### PR TITLE
fix random seed for tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-import pytest
 import numpy as np
+import pytest
 
 from meteor.testing import check_test_file_exists
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import numpy as np
 
 from meteor.testing import check_test_file_exists
 
@@ -25,3 +26,8 @@ def testing_mtz_file(data_dir: Path) -> Path:
     path = data_dir / "scaled-test-data.mtz"
     check_test_file_exists(path)
     return path
+
+
+@pytest.fixture(scope="session")
+def np_rng() -> np.random.Generator:
+    return np.random.default_rng(seed=0)

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -16,8 +16,6 @@ from meteor.rsmap import Map
 from meteor.tv import TvDenoiseResult
 from meteor.validate import negentropy
 
-NP_RNG = np.random.default_rng()
-
 
 def map_norm(map1: gemmi.Ccp4Map, map2: gemmi.Ccp4Map) -> float:
     diff = np.array(map1.grid) - np.array(map2.grid)
@@ -46,10 +44,10 @@ def normalized_rms(x: np.ndarray, y: np.ndarray) -> float:
 
 
 @pytest.mark.parametrize("scalar", [0.01, 1.0, 2.0, 100.0])
-def test_projected_derivative(scalar: float) -> None:
+def test_projected_derivative(scalar: float, np_rng: np.random.Generator) -> None:
     n = 16
-    native = NP_RNG.normal(size=n) + 1j * NP_RNG.normal(size=n)
-    derivative = NP_RNG.normal(size=n) + 1j * NP_RNG.normal(size=n)
+    native = np_rng.normal(size=n) + 1j * np_rng.normal(size=n)
+    derivative = np_rng.normal(size=n) + 1j * np_rng.normal(size=n)
     difference = derivative - native
 
     # ensure the projection removes a scalar multiple of the native & difference
@@ -63,13 +61,13 @@ def test_projected_derivative(scalar: float) -> None:
     np.testing.assert_allclose(proj_derivative, derivative)
 
 
-def test_complex_derivative_from_iterative_tv() -> None:
+def test_complex_derivative_from_iterative_tv(np_rng: np.random.Generator) -> None:
     test_image = binary_blobs(length=64)  # type: ignore[no-untyped-call]
 
     constant_image = np.ones_like(test_image) / 2.0
     constant_image_ft = np.fft.fftn(constant_image)
 
-    test_image_noisy = test_image + 0.2 * NP_RNG.normal(size=test_image.shape)
+    test_image_noisy = test_image + 0.2 * np_rng.normal(size=test_image.shape)
     test_image_noisy_ft = np.fft.fftn(test_image_noisy)
 
     denoised_derivative, _ = _complex_derivative_from_iterative_tv(

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -8,8 +8,6 @@ from meteor import utils
 from meteor.rsmap import Map
 from meteor.testing import MapColumns
 
-NP_RNG = np.random.default_rng()
-
 
 def omit_nones_in_list(input_list: list) -> list:
     return [x for x in input_list if x]

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -3,26 +3,24 @@ from numpy.testing import assert_almost_equal
 
 from meteor import validate
 
-NP_RNG = np.random.default_rng()
-
 
 def parabolic_objective(x: float) -> float:
     # has a maximum of y = 0 at x = 1
     return -(x**2) + 2 * x - 1
 
 
-def test_negentropy_gaussian() -> None:
+def test_negentropy_gaussian(np_rng: np.random.Generator) -> None:
     n_samples = 10000
-    samples = NP_RNG.normal(size=n_samples)
+    samples = np_rng.normal(size=n_samples)
     negentropy = validate.negentropy(samples)
 
     # negentropy should be zero for a Gaussian sample
     assert np.abs(negentropy) < 1e-2
 
 
-def test_negentropy_uniform() -> None:
+def test_negentropy_uniform(np_rng: np.random.Generator) -> None:
     n_samples = 1000000
-    samples = NP_RNG.uniform(size=n_samples)
+    samples = np_rng.uniform(size=n_samples)
     negentropy = validate.negentropy(samples)
 
     uniform_negentropy = (1.0 / 2.0) * np.log(np.pi * np.exp(1) / 6.0)


### PR DESCRIPTION
Our tests make heavy use of random numbers. Occasionally, they would fail. As the number of tests, platforms, python versions, etc grows, this will greatly increase the chance of flaky failures, which is bad.

To avoid this, we this PR proposes we fix the random seed for the tests, which makes them deterministic.