### PR TITLE
consistent handling of filled reflections

### DIFF
--- a/meteor/diffmaps.py
+++ b/meteor/diffmaps.py
@@ -56,8 +56,8 @@ def compute_difference_map(derivative: Map, native: Map) -> Map:
 
     derivative, native = filter_common_indices(derivative, native)
 
-    delta_complex = derivative.complex_amplitudes - native.complex_amplitudes
-    delta = Map.from_structurefactor(delta_complex, index=native.index)
+    delta_complex = derivative.to_structurefactor() - native.to_structurefactor()
+    delta = Map.from_structurefactor(delta_complex)
 
     set_common_crystallographic_metadata(derivative, native, output=delta)
 

--- a/meteor/diffmaps.py
+++ b/meteor/diffmaps.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 import numpy as np
 import reciprocalspaceship as rs
 
-from .rsmap import Map, _assert_is_map
+from .rsmap import Map, assert_is_map
 from .settings import DEFAULT_KPARAMS_TO_SCAN
 from .utils import filter_common_indices
 from .validate import ScalarMaximizer, map_negentropy
@@ -51,8 +51,8 @@ def compute_difference_map(derivative: Map, native: Map) -> Map:
     diffmap: Map
         map corresponding to the complex difference (derivative - native)
     """
-    _assert_is_map(derivative, require_uncertainties=False)
-    _assert_is_map(native, require_uncertainties=False)
+    assert_is_map(derivative, require_uncertainties=False)
+    assert_is_map(native, require_uncertainties=False)
 
     derivative, native = filter_common_indices(derivative, native)
 
@@ -85,7 +85,7 @@ def compute_kweights(difference_map: Map, *, k_parameter: float) -> rs.DataSerie
         A series of computed weights, where higher uncertainties and larger differences lead to
         lower weights.
     """
-    _assert_is_map(difference_map, require_uncertainties=True)
+    assert_is_map(difference_map, require_uncertainties=True)
 
     inverse_weights = (
         1
@@ -117,8 +117,8 @@ def compute_kweighted_difference_map(derivative: Map, native: Map, *, k_paramete
         the k-weighted difference map
     """
     # require uncertainties at the beginning
-    _assert_is_map(derivative, require_uncertainties=True)
-    _assert_is_map(native, require_uncertainties=True)
+    assert_is_map(derivative, require_uncertainties=True)
+    assert_is_map(native, require_uncertainties=True)
 
     difference_map = compute_difference_map(derivative, native)
     weights = compute_kweights(difference_map, k_parameter=k_parameter)
@@ -159,8 +159,8 @@ def max_negentropy_kweighted_difference_map(
     opt_k_parameter: float
         optimized k-weighting parameter
     """
-    _assert_is_map(derivative, require_uncertainties=True)
-    _assert_is_map(native, require_uncertainties=True)
+    assert_is_map(derivative, require_uncertainties=True)
+    assert_is_map(native, require_uncertainties=True)
 
     def negentropy_objective(k_parameter: float) -> float:
         kweighted_map = compute_kweighted_difference_map(

--- a/meteor/diffmaps.py
+++ b/meteor/diffmaps.py
@@ -10,7 +10,7 @@ import reciprocalspaceship as rs
 from .rsmap import Map, _assert_is_map
 from .settings import DEFAULT_KPARAMS_TO_SCAN, MAP_SAMPLING
 from .utils import filter_common_indices
-from .validate import ScalarMaximizer, negentropy
+from .validate import ScalarMaximizer, map_negentropy
 
 
 def set_common_crystallographic_metadata(map1: Map, map2: Map, *, output: Map) -> None:
@@ -163,14 +163,12 @@ def max_negentropy_kweighted_difference_map(
     _assert_is_map(native, require_uncertainties=True)
 
     def negentropy_objective(k_parameter: float) -> float:
-        kweighted_dataset = compute_kweighted_difference_map(
+        kweighted_map = compute_kweighted_difference_map(
             derivative,
             native,
             k_parameter=k_parameter,
         )
-        k_weighted_map = kweighted_dataset.to_ccp4_map(map_sampling=MAP_SAMPLING)
-        k_weighted_map_array = np.array(k_weighted_map.grid)
-        return negentropy(k_weighted_map_array)
+        return map_negentropy(kweighted_map)
 
     maximizer = ScalarMaximizer(objective=negentropy_objective)
     maximizer.optimize_over_explicit_values(arguments_to_scan=k_parameter_values_to_scan)

--- a/meteor/diffmaps.py
+++ b/meteor/diffmaps.py
@@ -9,26 +9,11 @@ import reciprocalspaceship as rs
 
 from .rsmap import Map, assert_is_map
 from .settings import DEFAULT_KPARAMS_TO_SCAN
-from .utils import filter_common_indices
+from .utils import assert_isomorphous, filter_common_indices
 from .validate import ScalarMaximizer, map_negentropy
 
 
-def set_common_crystallographic_metadata(map1: Map, map2: Map, *, output: Map) -> None:
-    if hasattr(map1, "cell"):
-        if hasattr(map2, "cell") and (map1.cell != map2.cell):
-            msg = f"`map1.cell` {map1.cell} != `map2.cell` {map2.cell}"
-            raise AttributeError(msg)
-        output.cell = map1.cell
-
-    if hasattr(map1, "spacegroup"):
-        if hasattr(map2, "spacegroup") and (map1.spacegroup != map2.spacegroup):
-            msg = f"`map1.spacegroup` {map1.spacegroup} != "
-            msg += f"`map2.spacegroup` {map2.spacegroup}"
-            raise AttributeError(msg)
-        output.spacegroup = map1.spacegroup
-
-
-def compute_difference_map(derivative: Map, native: Map) -> Map:
+def compute_difference_map(derivative: Map, native: Map, *, check_isomorphous: bool = True) -> Map:
     """
     Computes amplitude and phase differences between native and derivative structure factor sets.
 
@@ -43,8 +28,12 @@ def compute_difference_map(derivative: Map, native: Map) -> Map:
     ----------
     derivative: Map
         the derivative amplitudes, phases, uncertainties
+
     native: Map
         the native amplitudes, phases, uncertainties
+
+    check_isomorphous: bool
+        perform a check to ensure the two datasets are isomorphous; recommended. Default: True.
 
     Returns
     -------
@@ -53,13 +42,16 @@ def compute_difference_map(derivative: Map, native: Map) -> Map:
     """
     assert_is_map(derivative, require_uncertainties=False)
     assert_is_map(native, require_uncertainties=False)
+    if check_isomorphous:
+        assert_isomorphous(derivative=derivative, native=native)
 
     derivative, native = filter_common_indices(derivative, native)
 
     delta_complex = derivative.to_structurefactor() - native.to_structurefactor()
     delta = Map.from_structurefactor(delta_complex)
 
-    set_common_crystallographic_metadata(derivative, native, output=delta)
+    delta.cell = native.cell
+    delta.spacegroup = native.spacegroup
 
     if derivative.has_uncertainties and native.has_uncertainties:
         prop_uncertainties = np.sqrt(derivative.uncertainties**2 + native.uncertainties**2)
@@ -76,6 +68,7 @@ def compute_kweights(difference_map: Map, *, k_parameter: float) -> rs.DataSerie
     ----------
     difference_map: Map
         A map of structure factor differences (DeltaF).
+
     k_parameter: float
         A scaling factor applied to the squared `df` values in the weight calculation.
 
@@ -95,7 +88,9 @@ def compute_kweights(difference_map: Map, *, k_parameter: float) -> rs.DataSerie
     return 1.0 / inverse_weights
 
 
-def compute_kweighted_difference_map(derivative: Map, native: Map, *, k_parameter: float) -> Map:
+def compute_kweighted_difference_map(
+    derivative: Map, native: Map, *, k_parameter: float, check_isomorphous: bool = True
+) -> Map:
     """
     Compute k-weighted derivative - native structure factor map.
 
@@ -108,8 +103,12 @@ def compute_kweighted_difference_map(derivative: Map, native: Map, *, k_paramete
     ----------
     derivative: Map
         the derivative amplitudes, phases, uncertainties
+
     native: Map
         the native amplitudes, phases, uncertainties
+
+    check_isomorphous: bool
+        perform a check to ensure the two datasets are isomorphous; recommended. Default: True.
 
     Returns
     -------
@@ -119,8 +118,10 @@ def compute_kweighted_difference_map(derivative: Map, native: Map, *, k_paramete
     # require uncertainties at the beginning
     assert_is_map(derivative, require_uncertainties=True)
     assert_is_map(native, require_uncertainties=True)
+    if check_isomorphous:
+        assert_isomorphous(derivative=derivative, native=native)
 
-    difference_map = compute_difference_map(derivative, native)
+    difference_map = compute_difference_map(derivative, native, check_isomorphous=check_isomorphous)
     weights = compute_kweights(difference_map, k_parameter=k_parameter)
 
     difference_map.amplitudes *= weights
@@ -134,6 +135,7 @@ def max_negentropy_kweighted_difference_map(
     native: Map,
     *,
     k_parameter_values_to_scan: np.ndarray | Sequence[float] = DEFAULT_KPARAMS_TO_SCAN,
+    check_isomorphous: bool = True,
 ) -> rs.DataSet:
     """
     Compute k-weighted differences between native and derivative amplitudes and phases.
@@ -146,10 +148,15 @@ def max_negentropy_kweighted_difference_map(
     ----------
     derivative: Map
         the derivative amplitudes, phases, uncertainties
+
     native: Map
         the native amplitudes, phases, uncertainties
+
     k_parameter_values_to_scan : np.ndarray | Sequence[float]
         The values to scan to optimize the k-weighting parameter, by default is 0.00, 0.01 ... 1.00
+
+    check_isomorphous: bool
+        perform a check to ensure the two datasets are isomorphous; recommended. Default: True.
 
     Returns
     -------
@@ -161,12 +168,15 @@ def max_negentropy_kweighted_difference_map(
     """
     assert_is_map(derivative, require_uncertainties=True)
     assert_is_map(native, require_uncertainties=True)
+    if check_isomorphous:
+        assert_isomorphous(derivative=derivative, native=native)
 
     def negentropy_objective(k_parameter: float) -> float:
         kweighted_map = compute_kweighted_difference_map(
             derivative,
             native,
             k_parameter=k_parameter,
+            check_isomorphous=check_isomorphous,
         )
         return map_negentropy(kweighted_map)
 
@@ -178,6 +188,7 @@ def max_negentropy_kweighted_difference_map(
         derivative,
         native,
         k_parameter=opt_k_parameter,
+        check_isomorphous=check_isomorphous,
     )
 
     return kweighted_dataset, opt_k_parameter

--- a/meteor/diffmaps.py
+++ b/meteor/diffmaps.py
@@ -8,7 +8,7 @@ import numpy as np
 import reciprocalspaceship as rs
 
 from .rsmap import Map, _assert_is_map
-from .settings import DEFAULT_KPARAMS_TO_SCAN, MAP_SAMPLING
+from .settings import DEFAULT_KPARAMS_TO_SCAN
 from .utils import filter_common_indices
 from .validate import ScalarMaximizer, map_negentropy
 

--- a/meteor/iterative.py
+++ b/meteor/iterative.py
@@ -24,12 +24,13 @@ from .utils import (
 log = structlog.get_logger()
 
 
+# TODO: do we need this function?
 def _project_derivative_on_experimental_set(
     *,
-    native: np.ndarray,
-    derivative_amplitudes: np.ndarray,
-    difference: np.ndarray,
-) -> np.ndarray:
+    native: np.ndarray | rs.DataSeries,
+    derivative_amplitudes: np.ndarray | rs.DataSeries,
+    difference: np.ndarray | rs.DataSeries,
+) -> np.ndarray | rs.DataSeries:
     """
     Project the `derivative` structure factor onto the set of experimentally observed amplitudes.
 
@@ -66,7 +67,7 @@ def _complex_derivative_from_iterative_tv(  # noqa: PLR0913
     *,
     native: rs.DataSeries,
     initial_derivative: rs.DataSeries,
-    tv_denoise_function: Callable[[np.ndarray], tuple[np.ndarray, TvDenoiseResult]],
+    tv_denoise_function: Callable[[rs.DataSeries], tuple[rs.DataSeries, TvDenoiseResult]],
     convergence_tolerance: float = ITERATIVE_TV_CONVERGENCE_TOLERANCE,
     max_iterations: int = ITERATIVE_TV_MAX_ITERATIONS,
     verbose: bool = False,
@@ -85,10 +86,10 @@ def _complex_derivative_from_iterative_tv(  # noqa: PLR0913
         The complex derivative structure factors, usually with experimental amplitudes and esimated
         phases (often calculated from the native structure)
 
-    tv_denoise_function: Callable[[np.ndarray], tuple[np.ndarray, TvDenoiseResult]]
+    tv_denoise_function: Callable[[rs.DataSeries], tuple[rs.DataSeries, TvDenoiseResult]]
         A function capable of applying the TV denoising operation to *Fourier space* objects. This
-        function should therefore map one complex np.ndarray to a denoised complex np.ndarray and
-        the TvDenoiseResult for that TV run.
+        function should therefore map one complex rs.DataSeries to a denoised complex rs.DataSeries
+        and the TvDenoiseResult for that TV run.
 
     convergance_tolerance: float
         If the change in the estimated derivative SFs drops below this value (phase, per-component)
@@ -222,7 +223,6 @@ def iterative_tv_phase_retrieval(  # noqa: PLR0913
 
     # clean TV denoising interface that is crystallographically intelligent
     # maintains state for the HKL index, spacegroup, and cell information
-    # TODO: swap to DataSeries...
     def tv_denoise_closure(
         complex_difference_sf: rs.DataSeries,
     ) -> tuple[rs.DataSeries, TvDenoiseResult]:

--- a/meteor/iterative.py
+++ b/meteor/iterative.py
@@ -14,7 +14,7 @@ from .settings import (
     ITERATIVE_TV_MAX_ITERATIONS,
 )
 from .tv import TvDenoiseResult, tv_denoise_difference_map
-from .utils import CellType, SpacegroupType, average_phase_diff_in_degrees
+from .utils import CellType, SpacegroupType, assert_isomorphous, average_phase_diff_in_degrees
 
 log = structlog.get_logger()
 
@@ -214,6 +214,7 @@ class IterativeTvDenoiser:
         *,
         derivative: Map,
         native: Map,
+        check_isomorphous: bool = True,
     ) -> tuple[Map, pd.DataFrame]:
         """
         Denoise by estimating new, low-TV phases for the `derivative` dataset.
@@ -226,6 +227,9 @@ class IterativeTvDenoiser:
         native: Map
             the native amplitudes, phases
 
+        check_isomorphous: bool
+            perform a check to ensure the two datasets are isomorphous; recommended. Default: True.
+
         Returns
         -------
         updated_derivative: Map
@@ -236,10 +240,8 @@ class IterativeTvDenoiser:
             the tv_weight used, the negentropy (after the TV step), and the average phase change in
             degrees.
         """
-        # TODO: do we need this?
-        # initial_derivative, native = filter_common_indices(initial_derivative, native)
-
-        # TODO: check isomorphous
+        if check_isomorphous:
+            assert_isomorphous(derivative=derivative, native=native)
 
         it_tv_complex_derivative, metadata = self._iteratively_denoise_sf_amplitudes(
             native=native.to_structurefactor(),

--- a/meteor/iterative.py
+++ b/meteor/iterative.py
@@ -114,7 +114,6 @@ def _complex_derivative_from_iterative_tv(  # noqa: PLR0913
 
     # do the difference as rs.DataSeries, handles missing indices
     difference = initial_derivative - native
-    difference = difference
 
     converged: bool = False
     num_iterations: int = 0
@@ -154,12 +153,6 @@ def _complex_derivative_from_iterative_tv(  # noqa: PLR0913
         if num_iterations > max_iterations:
             break
 
-    # derivative_as_rs_series = rs.DataSeries(
-    #     derivative,
-    #     index=initial_derivative.index,
-    #     dtype=initial_derivative.dtypes,
-    #     name="derivative"
-    # )
     return derivative, pd.DataFrame(metadata)
 
 

--- a/meteor/iterative.py
+++ b/meteor/iterative.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import reciprocalspaceship as rs
 import structlog
-from reciprocalspaceship.decorators import cellify, spacegroupify
 
 from .rsmap import Map
 from .settings import (
@@ -15,19 +14,15 @@ from .settings import (
     ITERATIVE_TV_MAX_ITERATIONS,
 )
 from .tv import TvDenoiseResult, tv_denoise_difference_map
-from .utils import CellType, SpacegroupType, average_phase_diff_in_degrees, filter_common_indices
+from .utils import CellType, SpacegroupType, average_phase_diff_in_degrees
 
 log = structlog.get_logger()
 
 
-class _IterativeTvDenoiser:
-    @cellify("cell")
-    @spacegroupify("spacegroup")
-    def __init__(  # noqa: PLR0913
+class IterativeTvDenoiser:
+    def __init__(
         self,
         *,
-        cell: CellType,
-        spacegroup: SpacegroupType,
         convergence_tolerance: float = ITERATIVE_TV_CONVERGENCE_TOLERANCE,
         max_iterations: int = ITERATIVE_TV_MAX_ITERATIONS,
         tv_weights_to_scan: list[float] = DEFAULT_TV_WEIGHTS_TO_SCAN_AT_EACH_ITERATION,
@@ -38,12 +33,6 @@ class _IterativeTvDenoiser:
 
         Parameters
         ----------
-        cell: gemmi.Cell | Sequence[float] | np.ndarray
-            Unit cell, should match both the `native` and `derivative` datasets (usual: use native)
-
-        spacegroup: gemmi.SpaceGroup | str | int
-            The spacegroup; both the `native` and `derivative` datasets
-
         convergance_tolerance: float
             If the change in the estimated derivative SFs drops below this value (phase,
             per-component) then return. Default 1e-4.
@@ -58,8 +47,6 @@ class _IterativeTvDenoiser:
         verbose: bool
             Log or not.
         """
-        self.cell = cell
-        self.spacegroup = spacegroup
         self.tv_weights_to_scan = tv_weights_to_scan
         self.convergence_tolerance = convergence_tolerance
         self.max_iterations = max_iterations
@@ -72,15 +59,32 @@ class _IterativeTvDenoiser:
                 max_iterations=max_iterations,
             )
 
+    def _check_valid_isomorphous_inputs(
+        self, native: rs.DataSeries, initial_derivative: rs.DataSeries
+    ) -> None:
+        if not isinstance(native, rs.DataSeries):
+            msg = f"`native` must be type rs.DataSeries, got {type(native)}"
+            raise TypeError(msg)
+
+        if not isinstance(initial_derivative, rs.DataSeries):
+            msg = f"`initial_derivative` must be type rs.DataSeries, got {type(initial_derivative)}"
+            raise TypeError(msg)
+
+        # TODO: isomorphous bit
+
     def _tv_denoise_complex_difference_sf(
-        self, complex_difference_sf: rs.DataSeries
+        self,
+        complex_difference_sf: rs.DataSeries,
+        *,
+        cell: CellType,
+        spacegroup: SpacegroupType,
     ) -> tuple[rs.DataSeries, TvDenoiseResult]:
         """Apply a single iteration of TV denoising to set of complex SFs, return complex SFs"""
         diffmap = Map.from_structurefactor(
             complex_difference_sf,
             index=complex_difference_sf.index,
-            cell=self.cell,
-            spacegroup=self.spacegroup,
+            cell=cell,
+            spacegroup=spacegroup,
         )
 
         denoised_map, tv_metadata = tv_denoise_difference_map(
@@ -91,11 +95,13 @@ class _IterativeTvDenoiser:
 
         return denoised_map.to_structurefactor(), tv_metadata
 
-    def __call__(
+    def _iteratively_denoise_sf_amplitudes(
         self,
         *,
-        native: rs.DataSeries,
         initial_derivative: rs.DataSeries,
+        native: rs.DataSeries,
+        cell: CellType,
+        spacegroup: SpacegroupType,
     ) -> tuple[rs.DataSeries, pd.DataFrame]:
         """
         Estimate the derivative phases using the iterative TV algorithm.
@@ -111,6 +117,12 @@ class _IterativeTvDenoiser:
             The complex derivative structure factors, usually with experimental amplitudes and esimated
             phases (often calculated from the native structure)
 
+        cell: gemmi.Cell | Sequence[float] | np.ndarray
+            Unit cell, should match both the `native` and `derivative` datasets (usual: use native)
+
+        spacegroup: gemmi.SpaceGroup | str | int
+            The spacegroup; both the `native` and `derivative` datasets
+
         Returns
         -------
         estimated_complex_derivative: rs.DataSeries
@@ -121,15 +133,9 @@ class _IterativeTvDenoiser:
             the tv_weight used, the negentropy (after the TV step), and the average phase change in
             degrees.
         """
-        if not isinstance(native, rs.DataSeries):
-            msg = f"`native` must be type rs.DataSeries, got {type(native)}"
-            raise TypeError(msg)
-
-        if not isinstance(initial_derivative, rs.DataSeries):
-            msg = f"`initial_derivative` must be type rs.DataSeries, got {type(initial_derivative)}"
-            raise TypeError(msg)
-
         derivative = initial_derivative.copy()
+        self._check_valid_isomorphous_inputs(native, derivative)
+
         converged: bool = False
         num_iterations: int = 0
         metadata: list[dict[str, float]] = []
@@ -138,11 +144,13 @@ class _IterativeTvDenoiser:
         difference: rs.DataSeries = initial_derivative - native
 
         while not converged:
-            denoised_difference, tv_metadata = self._tv_denoise_complex_difference_sf(difference)
+            denoised_difference_sfs, tv_metadata = self._tv_denoise_complex_difference_sf(
+                difference, cell=cell, spacegroup=spacegroup
+            )
 
             # project onto the native amplitudes to obtain an "updated_derivative"
             #   Fh' = (D_F' + F) * [|Fh| / |D_F' + F|]
-            updated_derivative: rs.DataSeries = denoised_difference + native
+            updated_derivative: rs.DataSeries = denoised_difference_sfs + native
             updated_derivative *= np.abs(derivative) / np.abs(updated_derivative)
 
             # compute phase change, THEN set: derivative <- updated_derivative
@@ -175,95 +183,73 @@ class _IterativeTvDenoiser:
 
         return derivative, pd.DataFrame(metadata)
 
+    def __call__(
+        self,
+        *,
+        derivative: Map,
+        native: Map,
+    ) -> tuple[Map, pd.DataFrame]:
+        """
+        Here is a brief pseudocode sketch of the alogrithm. Structure factors F below are complex
+        unless explicitly annotated |*|.
 
-def iterative_tv_phase_retrieval(  # noqa: PLR0913
-    initial_derivative: Map,
-    native: Map,
-    *,
-    convergence_tolerance: float = ITERATIVE_TV_CONVERGENCE_TOLERANCE,
-    max_iterations: int = ITERATIVE_TV_MAX_ITERATIONS,
-    tv_weights_to_scan: list[float] = DEFAULT_TV_WEIGHTS_TO_SCAN_AT_EACH_ITERATION,
-    verbose: bool = False,
-) -> tuple[Map, pd.DataFrame]:
-    """
-    Here is a brief pseudocode sketch of the alogrithm. Structure factors F below are complex unless
-    explicitly annotated |*|.
+            Input: |F|, |Fh|, phi_c
+            Note: F = |F| * exp{ phi_c } is the native/dark data,
+                |Fh| represents the derivative/triggered/light data
 
-        Input: |F|, |Fh|, phi_c
-        Note: F = |F| * exp{ phi_c } is the native/dark data,
-             |Fh| represents the derivative/triggered/light data
+            Initialize:
+            - D_F = ( |Fh| - |F| ) * exp{ phi_c }
 
-        Initialize:
-         - D_F = ( |Fh| - |F| ) * exp{ phi_c }
+            while not converged:
+                D_rho = FT{ D_F }                       Fourier transform
+                D_rho' = TV{ D_rho }                    TV denoise: apply real space prior
+                D_F' = FT-1{ D_rho' }                   back Fourier transform
+                Fh' = (D_F' + F) * [|Fh| / |D_F' + F|]  Fourier space projection to experimental set
+                D_F = Fh' - F
 
-        while not converged:
-            D_rho = FT{ D_F }                       Fourier transform
-            D_rho' = TV{ D_rho }                    TV denoise: apply real space prior
-            D_F' = FT-1{ D_rho' }                   back Fourier transform
-            Fh' = (D_F' + F) * [|Fh| / |D_F' + F|]  Fourier space projection onto experimental set
-            D_F = Fh' - F
+        Where the TV weight parameter is determined using golden section optimization. The algorithm
+        iterates until the changes in the derivative phase drop below a specified threshold.
 
-    Where the TV weight parameter is determined using golden section optimization. The algorithm
-    iterates until the changes in the derivative phase drop below a specified threshold.
+        Parameters
+        ----------
+        derivative: Map
+            the derivative amplitudes, and initial guess for the phases
 
-    Parameters
-    ----------
-    initial_derivative: Map
-        the derivative amplitudes, and initial guess for the phases
+        native: Map
+            the native amplitudes, phases
 
-    native: Map
-        the native amplitudes, phases
+        Returns
+        -------
+        updated_derivative: Map
+            The estimated derivative phases, along with the input amplitudes and input phases.
 
-    convergance_tolerance: float
-        If the change in the estimated derivative SFs drops below this value (phase, per-component)
-        then return. Default 1e-4.
+        metadata: pd.DataFrame
+            Information about the algorithm run as a function of iteration. For each step, includes:
+            the tv_weight used, the negentropy (after the TV step), and the average phase change in
+            degrees.
+        """
+        # TODO: do we need this?
+        # initial_derivative, native = filter_common_indices(initial_derivative, native)
 
-    max_iterations: int
-        If this number of iterations is reached, stop early. Default 1000.
+        # TODO: check isomorphous
 
-    tv_weights_to_scan : list[float], optional
-        A list of TV regularization weights (λ values) to be scanned for optimal results,
-        by default [0.001, 0.01, 0.1, 1.0].
-
-    verbose: bool
-        Log or not.
-
-    Returns
-    -------
-    output_map: Map
-        The estimated derivative phases, along with the input amplitudes and input computed phases.
-
-    metadata: pd.DataFrame
-        Information about the algorithm run as a function of iteration. For each step, includes:
-        the tv_weight used, the negentropy (after the TV step), and the average phase change in
-        degrees.
-    """
-    initial_derivative, native = filter_common_indices(initial_derivative, native)
-
-    denoiser = _IterativeTvDenoiser(
-        cell=native.cell,
-        spacegroup=native.spacegroup,
-        convergence_tolerance=convergence_tolerance,
-        max_iterations=max_iterations,
-        tv_weights_to_scan=tv_weights_to_scan,
-        verbose=verbose,
-    )
-
-    it_tv_complex_derivative, metadata = denoiser(
-        native=native.to_structurefactor(),
-        initial_derivative=initial_derivative.to_structurefactor(),
-    )
-
-    updated_derivative_map = Map.from_structurefactor(
-        it_tv_complex_derivative,
-        cell=initial_derivative.cell,
-        spacegroup=initial_derivative.spacegroup,
-    )
-
-    if initial_derivative.has_uncertainties:
-        updated_derivative_map.set_uncertainties(
-            initial_derivative.uncertainties,
-            column_name=initial_derivative.uncertainties_column_name,
+        it_tv_complex_derivative, metadata = self._iteratively_denoise_sf_amplitudes(
+            native=native.to_structurefactor(),
+            initial_derivative=derivative.to_structurefactor(),
+            cell=native.cell,
+            spacegroup=native.spacegroup,
         )
 
-    return updated_derivative_map, metadata
+        updated_derivative_map = Map.from_structurefactor(
+            it_tv_complex_derivative,
+            cell=derivative.cell,
+            spacegroup=derivative.spacegroup,
+        )
+
+        if derivative.has_uncertainties:
+            updated_derivative_map.set_uncertainties(
+                derivative.uncertainties,
+                column_name=derivative.uncertainties_column_name,
+            )
+
+        return updated_derivative_map, metadata

--- a/meteor/rsmap.py
+++ b/meteor/rsmap.py
@@ -28,7 +28,7 @@ class MissingUncertaintiesError(AttributeError): ...
 class MapMutabilityError(RuntimeError): ...
 
 
-def _assert_is_map(obj: Any, *, require_uncertainties: bool) -> None:
+def assert_is_map(obj: Any, *, require_uncertainties: bool) -> None:
     if not isinstance(obj, Map):
         msg = f"expected {obj} to be a rsmap.Map, got {type(obj)}"
         raise TypeError(msg)

--- a/meteor/rsmap.py
+++ b/meteor/rsmap.py
@@ -300,15 +300,10 @@ class Map(rs.DataSet):
         msg = "uncertainties not set for Map object"
         raise AttributeError(msg)
 
-    # TODO: this is redundant with to_structurefactor
+    # TODO: combine with complex_structurefactor()
     @property
-    def complex_amplitudes(self, *, astype: Literal["numpy", "DataSeries"] = "numpy") -> np.ndarray:
-        # TODO: work, test
-        if astype == "numpy":
-            return self.amplitudes.to_numpy() * np.exp(1j * np.deg2rad(self.phases.to_numpy()))
-        if astype == "DataSeries":
-            return self.amplitudes * np.exp(1j * np.deg2rad(self.phases))
-        raise ValueError  # TODO: write
+    def complex_amplitudes(self) -> np.ndarray:
+        return self.amplitudes.to_numpy() * np.exp(1j * np.deg2rad(self.phases.to_numpy()))
 
     def canonicalize_amplitudes(self) -> None:
         canonicalize_amplitudes(

--- a/meteor/rsmap.py
+++ b/meteor/rsmap.py
@@ -300,11 +300,6 @@ class Map(rs.DataSet):
         msg = "uncertainties not set for Map object"
         raise AttributeError(msg)
 
-    # TODO: combine with complex_structurefactor()
-    @property
-    def complex_amplitudes(self) -> np.ndarray:
-        return self.amplitudes.to_numpy() * np.exp(1j * np.deg2rad(self.phases.to_numpy()))
-
     def canonicalize_amplitudes(self) -> None:
         canonicalize_amplitudes(
             self,
@@ -314,6 +309,7 @@ class Map(rs.DataSet):
         )
 
     def to_structurefactor(self) -> rs.DataSeries:
+        """Return a DataSeries of complex structure factor amplitudes"""
         return super().to_structurefactor(self._amplitude_column, self._phase_column)
 
     # TODO: overload typing, docstring

--- a/meteor/scripts/common.py
+++ b/meteor/scripts/common.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 from dataclasses import dataclass
 from enum import StrEnum, auto
 from io import StringIO
@@ -34,7 +33,6 @@ INFER_COLUMN_NAME: str = "infer"
 PHASE_COLUMN_NAME: str = "PHI"
 DEFAULT_OUTPUT_MTZ: Path = Path("meteor_difference_map.mtz")
 DEFAULT_OUTPUT_METADATA_FILE: Path = Path("meteor_metadata.json")
-FLOAT_REGEX: re.Pattern = re.compile(r"^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$")
 
 
 class InvalidWeightModeError(ValueError): ...

--- a/meteor/scripts/compute_difference_map.py
+++ b/meteor/scripts/compute_difference_map.py
@@ -10,7 +10,7 @@ import structlog
 from meteor.rsmap import Map
 from meteor.settings import MAP_SAMPLING, TV_WEIGHT_DEFAULT
 from meteor.tv import TvDenoiseResult, tv_denoise_difference_map
-from meteor.validate import negentropy
+from meteor.validate import map_negentropy
 
 from .common import (
     DiffmapArgParser,
@@ -117,16 +117,14 @@ def denoise_diffmap_according_to_mode(
 
     elif tv_denoise_mode == WeightMode.none:
         final_map = diffmap
-
-        realspace_map = final_map.to_ccp4_map(map_sampling=MAP_SAMPLING)
-        map_negetropy = negentropy(np.array(realspace_map.grid))
+        final_negentropy = map_negentropy(final_map)
         metadata = TvDenoiseResult(
-            initial_negentropy=map_negetropy,
-            optimal_negentropy=map_negetropy,
+            initial_negentropy=final_negentropy,
+            optimal_negentropy=final_negentropy,
             optimal_tv_weight=0.0,
             map_sampling_used_for_tv=MAP_SAMPLING,
             tv_weights_scanned=[0.0],
-            negentropy_at_weights=[map_negetropy],
+            negentropy_at_weights=[final_negentropy],
         )
 
         log.info("Requested no TV denoising")

--- a/meteor/scripts/compute_difference_map.py
+++ b/meteor/scripts/compute_difference_map.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import numpy as np
 import structlog
 
 from meteor.rsmap import Map

--- a/meteor/scripts/compute_iterative_tv_map.py
+++ b/meteor/scripts/compute_iterative_tv_map.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import structlog
 
-from meteor.iterative import iterative_tv_phase_retrieval
+from meteor.iterative import IterativeTvDenoiser
 from meteor.settings import (
     DEFAULT_TV_WEIGHTS_TO_SCAN_AT_EACH_ITERATION,
     ITERATIVE_TV_CONVERGENCE_TOLERANCE,
@@ -74,15 +74,13 @@ def main(command_line_arguments: list[str] | None = None) -> None:
 
     log.info("Launching iterative TV phase retrieval", tv_weights_to_scan=args.tv_weights_to_scan)
     log.info("This will take time, typically minutes...")
-    new_derivative_map, it_tv_metadata = iterative_tv_phase_retrieval(
-        mapset.derivative,
-        mapset.native,
+    denoiser = IterativeTvDenoiser(
         tv_weights_to_scan=args.tv_weights_to_scan,
         convergence_tolerance=args.convergence_tolerance,
         max_iterations=args.max_iterations,
         verbose=True,
     )
-    mapset.derivative = new_derivative_map
+    mapset.derivative, it_tv_metadata = denoiser(derivative=mapset.derivative, native=mapset.native)
     log.info("Convergence.")
 
     diffmap, kparameter_used = kweight_diffmap_according_to_mode(

--- a/meteor/testing.py
+++ b/meteor/testing.py
@@ -9,6 +9,7 @@ import gemmi
 import numpy as np
 
 from .rsmap import Map
+from .settings import MAP_SAMPLING
 
 
 @dataclass
@@ -27,11 +28,9 @@ def assert_phases_allclose(array1: np.ndarray, array2: np.ndarray, atol: float =
         raise AssertionError(msg)
 
 
-# TODO: test
-def rms_between_coefficients(map1: Map, map2: Map) -> float:
-    map_sampling = 3
-    map1_array = np.array(map1.to_ccp4_map(map_sampling=map_sampling).grid)
-    map2_array = np.array(map2.to_ccp4_map(map_sampling=map_sampling).grid)
+def diffmap_realspace_rms(map1: Map, map2: Map) -> float:
+    map1_array = np.array(map1.to_ccp4_map(map_sampling=MAP_SAMPLING).grid)
+    map2_array = np.array(map2.to_ccp4_map(map_sampling=MAP_SAMPLING).grid)
 
     # standardize
     map1_array /= map1_array.std()

--- a/meteor/testing.py
+++ b/meteor/testing.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import gemmi
 import numpy as np
 
+from .rsmap import Map
+
 
 @dataclass
 class MapColumns:
@@ -23,6 +25,19 @@ def assert_phases_allclose(array1: np.ndarray, array2: np.ndarray, atol: float =
     if not absolute_difference < atol:
         msg = f"per element diff {absolute_difference} > tolerance {atol}"
         raise AssertionError(msg)
+
+
+# TODO: test
+def rms_between_coefficients(map1: Map, map2: Map) -> float:
+    map_sampling = 3
+    map1_array = np.array(map1.to_ccp4_map(map_sampling=map_sampling).grid)
+    map2_array = np.array(map2.to_ccp4_map(map_sampling=map_sampling).grid)
+
+    # standardize
+    map1_array /= map1_array.std()
+    map2_array /= map2_array.std()
+
+    return float(np.linalg.norm(map2_array - map1_array))
 
 
 def check_test_file_exists(path: Path) -> None:

--- a/meteor/tv.py
+++ b/meteor/tv.py
@@ -191,15 +191,6 @@ def tv_denoise_difference_map(
     if difference_map.has_uncertainties:
         final_map.set_uncertainties(difference_map.uncertainties)
 
-    # sometimes `from_ccp4_map` adds reflections -- systematic absences or
-    # reflections just beyond the resolution limt; remove those
-    extra_indices = final_map.index.difference(difference_map.index)
-    final_map.drop(extra_indices, inplace=True)
-    sym_diff = difference_map.index.symmetric_difference(final_map.index)
-    if len(sym_diff) > 0:
-        msg = "something went wrong, input and output coefficients do not have identical indices"
-        raise IndexError(msg)
-
     if full_output:
         initial_negentropy = negentropy(realspace_map_array)
         tv_result = TvDenoiseResult(

--- a/meteor/tv.py
+++ b/meteor/tv.py
@@ -126,10 +126,12 @@ def tv_denoise_difference_map(
     difference_map : Map
         The input dataset containing the difference map coefficients (amplitude and phase)
         that will be used to compute the difference map.
+
     full_output : bool, optional
         If `True`, the function returns both the denoised map coefficients and a `TvDenoiseResult`
          object containing the optimal weight and the associated negentropy. If `False`, only
          the denoised map coefficients are returned. Default is `False`.
+
     weights_to_scan : Sequence[float] | None, optional
         A sequence of weight values to explicitly scan for determining the optimal value. If
         `None`, the function uses the golden-section search method to determine the optimal

--- a/meteor/utils.py
+++ b/meteor/utils.py
@@ -8,7 +8,6 @@ from typing import Literal, overload
 import gemmi
 import numpy as np
 import reciprocalspaceship as rs
-from pandas import Index
 from reciprocalspaceship import DataSet
 from reciprocalspaceship.decorators import cellify, spacegroupify
 from reciprocalspaceship.utils import canonicalize_phases
@@ -102,65 +101,6 @@ def average_phase_diff_in_degrees(array1: np.ndarray, array2: np.ndarray) -> flo
     diff = (diff + 180) % 360 - 180
 
     return float(np.sum(np.abs(diff)) / float(np.prod(array1.shape)))
-
-
-# TODO: remove this function and subsume it into rsmap.from_structurefactor(...)
-def complex_array_to_rs_dataseries(
-    complex_structure_factors: np.ndarray,
-    *,
-    index: Index,
-) -> tuple[rs.DataSeries, rs.DataSeries]:
-    """
-    Convert an array of complex structure factors into two reciprocalspaceship DataSeries, one
-    representing the structure factor amplitudes and one for the phases.
-
-    Parameters
-    ----------
-    complex_structure_factors: np.ndarray
-        the complex-valued structure factors, as a numpy array
-    index: pandas.Index
-        the indices (HKL) for each structure factor in `complex_structure_factors`
-
-    Returns
-    -------
-    amplitudes: DataSeries
-        with StructureFactorAmplitudeDtype
-    phases: DataSeries
-        with PhaseDtype
-
-    Raises
-    ------
-    ValueError
-        if `complex_structure_factors and `index` do not have the same shape
-
-    See Also
-    --------
-    `reciprocalspaceship/utils/structurefactors.from_structurefactor(...)`
-        An equivalent function, that does not require the index and does less index/data
-        checking.
-    """
-    if complex_structure_factors.shape != index.shape:
-        msg = (
-            f"shape of `complex_structure_factors` ({complex_structure_factors.shape}) does not "
-            f"match shape of `index` ({index.shape})"
-        )
-        raise ShapeMismatchError(msg)
-
-    amplitudes = rs.DataSeries(
-        np.abs(complex_structure_factors),
-        index=index,
-        dtype=rs.StructureFactorAmplitudeDtype(),
-        name="F",
-    )
-
-    phases = rs.DataSeries(
-        np.angle(complex_structure_factors, deg=True),
-        index=index,
-        dtype=rs.PhaseDtype(),
-        name="PHI",
-    )
-
-    return amplitudes, phases
 
 
 @cellify("cell")

--- a/meteor/utils.py
+++ b/meteor/utils.py
@@ -84,9 +84,9 @@ def canonicalize_amplitudes(
     return None
 
 
-def average_phase_diff_in_degrees(array1: np.ndarray, array2: np.ndarray) -> float:
-    # TODO: make this work for numpy and DataSeries, test
-
+def average_phase_diff_in_degrees(
+    array1: np.ndarray | rs.DataSeries, array2: np.ndarray | rs.DataSeries
+) -> float:
     if isinstance(array1, rs.DataSeries) and isinstance(array2, rs.DataSeries):
         array1, array2 = filter_common_indices(array1, array2)
 

--- a/meteor/utils.py
+++ b/meteor/utils.py
@@ -19,6 +19,17 @@ SpacegroupType = str | int | gemmi.SpaceGroup
 class ShapeMismatchError(Exception): ...
 
 
+class NotIsomorphousError(RuntimeError): ...
+
+
+def assert_isomorphous(*, derivative: rs.DataSet, native: rs.DataSet) -> None:
+    if not native.is_isomorphous(derivative):
+        msg = "`derivative` and `native` datasets are not similar enough; "
+        msg += f"they have cell/spacegroup: {derivative.cell}/{native.cell} and "
+        msg += f"{derivative.spacegroup}/{native.spacegroup} respectively"
+        raise NotIsomorphousError(msg)
+
+
 def filter_common_indices(df1: DataSet, df2: DataSet) -> tuple[DataSet, DataSet]:
     common_indices = df1.index.intersection(df2.index)
     df1_common = df1.loc[common_indices].copy()

--- a/meteor/utils.py
+++ b/meteor/utils.py
@@ -86,16 +86,25 @@ def canonicalize_amplitudes(
 
 
 def average_phase_diff_in_degrees(array1: np.ndarray, array2: np.ndarray) -> float:
+    # TODO: make this work for numpy and DataSeries, test
+
+    if isinstance(array1, rs.DataSeries) and isinstance(array2, rs.DataSeries):
+        array1, array2 = filter_common_indices(array1, array2)
+
     if array1.shape != array2.shape:
         msg = f"inputs not same shape: {array1.shape} vs {array2.shape}"
         raise ShapeMismatchError(msg)
+
     phase1 = np.rad2deg(np.angle(array1))
     phase2 = np.rad2deg(np.angle(array2))
+
     diff = phase2 - phase1
     diff = (diff + 180) % 360 - 180
+
     return float(np.sum(np.abs(diff)) / float(np.prod(array1.shape)))
 
 
+# TODO: remove this function and subsume it into rsmap.from_structurefactor(...)
 def complex_array_to_rs_dataseries(
     complex_structure_factors: np.ndarray,
     *,

--- a/meteor/validate.py
+++ b/meteor/validate.py
@@ -7,8 +7,9 @@ from collections.abc import Callable, Sequence
 import numpy as np
 from scipy.optimize import minimize_scalar
 from scipy.stats import differential_entropy
-from .settings import MAP_SAMPLING
+
 from .rsmap import Map
+from .settings import MAP_SAMPLING
 
 
 def negentropy(samples: np.ndarray, *, tolerance: float = 0.1) -> float:
@@ -63,7 +64,7 @@ def negentropy(samples: np.ndarray, *, tolerance: float = 0.1) -> float:
     return float(neg_e)
 
 
-def map_negentropy(map: Map, *, tolerance: float = 0.1) -> float:
+def map_negentropy(map_to_assess: Map, *, tolerance: float = 0.1) -> float:
     """
     Computes the negentropy of a crystallographic map.
 
@@ -74,8 +75,8 @@ def map_negentropy(map: Map, *, tolerance: float = 0.1) -> float:
 
     Parameters
     ----------
-    samples: np.ndarray
-        A numpy array of sample data for which to calculate the negentropy.
+    map_to_assess: Map
+        The map (coefficients) we will compute the negentropy for.
 
     tolerance: float
         Tolerance level determining if the negentropy is suspiciously negative. Defaults to 0.1.
@@ -90,7 +91,7 @@ def map_negentropy(map: Map, *, tolerance: float = 0.1) -> float:
     ValueError: If the computed negentropy is less than the negative tolerance,
                 indicating potential issues with the computation.
     """
-    realspace_map = map.to_ccp4_map(map_sampling=MAP_SAMPLING)
+    realspace_map = map_to_assess.to_ccp4_map(map_sampling=MAP_SAMPLING)
     realspace_map_array = np.array(realspace_map.grid)
     return negentropy(realspace_map_array, tolerance=tolerance)
 

--- a/test/unit/test_diffmaps.py
+++ b/test/unit/test_diffmaps.py
@@ -14,7 +14,7 @@ from meteor.diffmaps import (
     set_common_crystallographic_metadata,
 )
 from meteor.rsmap import Map
-from meteor.validate import negentropy
+from meteor.validate import map_negentropy
 
 
 @pytest.fixture
@@ -156,9 +156,8 @@ def test_kweight_optimization(noise_free_map: rs.DataSet, noisy_map: rs.DataSet)
             noise_free_map,
             k_parameter=k_parameter,
         )
-        realspace_map = kweighted_diffmap.to_ccp4_map(map_sampling=3)
-        map_negentropy = negentropy(np.array(realspace_map.grid))
-        negentropies.append(map_negentropy)
+        diffmap_negentropy = map_negentropy(kweighted_diffmap)
+        negentropies.append(diffmap_negentropy)
 
     # the optimal k-weight should have the highest negentropy
     assert negentropies[0] <= negentropies[1]

--- a/test/unit/test_diffmaps.py
+++ b/test/unit/test_diffmaps.py
@@ -11,9 +11,9 @@ from meteor.diffmaps import (
     compute_kweighted_difference_map,
     compute_kweights,
     max_negentropy_kweighted_difference_map,
-    set_common_crystallographic_metadata,
 )
 from meteor.rsmap import Map
+from meteor.utils import NotIsomorphousError
 from meteor.validate import map_negentropy
 
 
@@ -40,36 +40,6 @@ def dummy_native() -> Map:
     return Map(native, index=index).infer_mtz_dtypes()
 
 
-def test_set_common_crystallographic_metadata(dummy_native: Map) -> None:
-    dummy_native.cell = (10.0, 10.0, 10.0, 90.0, 90.0, 90.0)
-    dummy_native.spacegroup = 1
-    map1 = dummy_native
-    map2 = dummy_native.copy()
-    output = dummy_native.copy()
-
-    # ensure things are copied when missing initially
-    del output._cell
-    del output._spacegroup
-    assert not hasattr(output, "cell")
-    assert not hasattr(output, "spacegroup")
-
-    set_common_crystallographic_metadata(map1, map2, output=output)
-
-    assert output.cell == map1.cell
-    assert output.spacegroup == map2.spacegroup
-
-    map2.spacegroup = 19
-    with pytest.raises(AttributeError):
-        set_common_crystallographic_metadata(map1, map2, output=output)
-
-    map2.spacegroup = 1
-    set_common_crystallographic_metadata(map1, map2, output=output)
-
-    dummy_native.cell = (15.0, 15.0, 15.0, 90.0, 90.0, 90.0)
-    with pytest.raises(AttributeError):
-        set_common_crystallographic_metadata(map1, map2, output=output)
-
-
 def test_compute_difference_map_vs_analytical(dummy_derivative: Map, dummy_native: Map) -> None:
     # Manually calculated expected amplitude and phase differences
     expected_amplitudes = np.array([3.0, 5.0])
@@ -77,43 +47,59 @@ def test_compute_difference_map_vs_analytical(dummy_derivative: Map, dummy_nativ
     assert isinstance(dummy_native, Map)
     assert isinstance(dummy_derivative, Map)
 
-    result = compute_difference_map(dummy_derivative, dummy_native)
+    result = compute_difference_map(dummy_derivative, dummy_native, check_isomorphous=False)
     assert_almost_equal(result.amplitudes, expected_amplitudes, decimal=4)
     assert_almost_equal(result.phases, expected_phases, decimal=4)
 
 
 @pytest.mark.parametrize(
     "diffmap_fxn",
+    # lambdas to make the call signatures for these functions match `compute_difference_map`
     [
-        compute_difference_map,
-        # lambdas to make the call signatures for these functions match `compute_difference_map`
-        lambda d, n: compute_kweighted_difference_map(d, n, k_parameter=0.5),
-        lambda d, n: max_negentropy_kweighted_difference_map(d, n)[0],
+        lambda d, n, check: compute_difference_map(d, n, check_isomorphous=check),
+        lambda d, n, check: compute_kweighted_difference_map(
+            d, n, k_parameter=0.5, check_isomorphous=check
+        ),
+        lambda d, n, check: max_negentropy_kweighted_difference_map(d, n, check_isomorphous=check)[
+            0
+        ],
     ],
 )
+@pytest.mark.parametrize("check_isomorphous", [True, False])
 def test_cell_spacegroup_propogation(
     diffmap_fxn: Callable,
     dummy_derivative: Map,
     dummy_native: Map,
+    check_isomorphous: bool,
 ) -> None:
+    # these should all cast to gemmi objects
     dummy_derivative.cell = (10.0, 10.0, 10.0, 90.0, 90.0, 90.0)
-    dummy_derivative.spacegroup = 1  # will cast to gemmi.SpaceGroup
-    dummy_native.cell = (10.0, 10.0, 10.0, 90.0, 90.0, 90.0)
+    dummy_derivative.spacegroup = 1
+    dummy_native.cell = (10.01, 10.01, 10.01, 90.01, 90.01, 90.01)
     dummy_native.spacegroup = 1
 
-    result = diffmap_fxn(dummy_derivative, dummy_native)
+    # ensure the native cell is propogated
+    result = diffmap_fxn(dummy_derivative, dummy_native, check_isomorphous)
     assert result.cell == dummy_native.cell
     assert result.spacegroup == dummy_native.spacegroup
 
+    # check we raise or dont with a spacegroup mismatch
     dummy_native.spacegroup = 19
-    with pytest.raises(AttributeError):
-        result = diffmap_fxn(dummy_derivative, dummy_native)
+    if check_isomorphous:
+        with pytest.raises(NotIsomorphousError):
+            _ = diffmap_fxn(dummy_derivative, dummy_native, check_isomorphous)
+    else:
+        _ = diffmap_fxn(dummy_derivative, dummy_native, check_isomorphous)
 
+    # check we raise or dont with a cell mismatch
     dummy_native.spacegroup = 1
-    _ = compute_difference_map(dummy_derivative, dummy_native)
-    dummy_native.cell = (15.0, 15.0, 15.0, 90.0, 90.0, 90.0)
-    with pytest.raises(AttributeError):
-        result = diffmap_fxn(dummy_derivative, dummy_native)
+    _ = diffmap_fxn(dummy_derivative, dummy_native, check_isomorphous)
+    dummy_native.cell = (20.0, 10.0, 10.0, 90.0, 90.0, 90.0)
+    if check_isomorphous:
+        with pytest.raises(NotIsomorphousError):
+            _ = diffmap_fxn(dummy_derivative, dummy_native, check_isomorphous)
+    else:
+        _ = diffmap_fxn(dummy_derivative, dummy_native, check_isomorphous)
 
 
 def test_compute_kweights_vs_analytical() -> None:
@@ -133,7 +119,9 @@ def test_compute_kweighted_difference_map_vs_analytical(
     dummy_derivative: Map,
     dummy_native: Map,
 ) -> None:
-    kwt_diffmap = compute_kweighted_difference_map(dummy_derivative, dummy_native, k_parameter=0.5)
+    kwt_diffmap = compute_kweighted_difference_map(
+        dummy_derivative, dummy_native, k_parameter=0.5, check_isomorphous=False
+    )
     expected_weighted_amplitudes = np.array([1.3247, 1.8280])  # calculated by hand
     expected_weighted_uncertainties = np.array([0.3122, 0.2585])
     assert_almost_equal(kwt_diffmap.amplitudes, expected_weighted_amplitudes, decimal=4)

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import gemmi
 import numpy as np
 import pandas as pd
 import pytest
+import reciprocalspaceship as rs
 
 from meteor.iterative import (
     IterativeTvDenoiser,
+    _assert_are_dataseries,
 )
 from meteor.rsmap import Map
 from meteor.testing import diffmap_realspace_rms
@@ -22,31 +23,42 @@ def testing_denoiser() -> IterativeTvDenoiser:
     )
 
 
-def map_norm(map1: gemmi.Ccp4Map, map2: gemmi.Ccp4Map) -> float:
-    diff = np.array(map1.grid) - np.array(map2.grid)
-    return float(np.linalg.norm(diff))
+def test_assert_are_dataseries() -> None:
+    ds = rs.DataSeries([1, -1, 1], index=[1, 2, 3])
+    _assert_are_dataseries(ds)
+    _assert_are_dataseries(ds, ds)
+
+    with pytest.raises(TypeError):
+        _assert_are_dataseries(1)  # type: ignore[arg-type]
 
 
-def test_IterativeTvDenoiser() -> None:
-    raise NotImplementedError
-
-    # denoised_derivative, _ = denoiser(
-    #     native=noise_free_map.to_structurefactor(),
-    #     initial_derivative=noisy_map.to_structurefactor(),
-    # )
-
-    # noisy_error = rms_between_coefficients(noisy_map, noise_free_map)
-    # denoised_error = rms_between_coefficients(denoised_derivative, noise_free_map)
-
-    # # insist on 5% improvement
-    # assert 1.05 * noisy_error < denoised_error
+def test_init(testing_denoiser: IterativeTvDenoiser) -> None:
+    assert isinstance(testing_denoiser, IterativeTvDenoiser)
 
 
-def test_tv_denoise_complex_difference_sf() -> None:
-    raise NotImplementedError
+def test_tv_denoise_complex_difference_sf(
+    testing_denoiser: IterativeTvDenoiser, np_rng: np.random.Generator
+) -> None:
+    # use a huge TV weight, make sure random noise goes down
+    testing_denoiser.tv_weights_to_scan = [100.0]
+    size = 256
+    noise = rs.DataSeries(np_rng.normal(size) + 1j * np_rng.normal(size), index=np.arange(size))
+
+    cell = [10.0, 10.0, 10.0, 90.0, 90.0, 90.0]
+    denoised_sfs, metadata = testing_denoiser._tv_denoise_complex_difference_sf(
+        noise, cell=cell, spacegroup=1
+    )
+
+    assert isinstance(denoised_sfs, rs.DataSeries)
+    assert isinstance(metadata, pd.DataFrame)
+
+    assert np.sum(np.abs(denoised_sfs)) < np.sum(np.abs(noise))
 
 
-def test_iterative_tv_different_indices(
+def test_iteratively_denoise_sf_amplitudes() -> None: ...
+
+
+def test_iterative_tv_denoiser_different_indices(
     noise_free_map: Map, very_noisy_map: Map, testing_denoiser: IterativeTvDenoiser
 ) -> None:
     # regression test to make sure we can accept maps with different indices
@@ -67,7 +79,7 @@ def test_iterative_tv_different_indices(
     assert isinstance(denoised_map, Map)
 
 
-def test_iterative_tv(
+def test_iterative_tv_denoiser(
     noise_free_map: Map, very_noisy_map: Map, testing_denoiser: IterativeTvDenoiser
 ) -> None:
     # the test case is the denoising of a difference: between a noisy map and its noise-free origin
@@ -77,6 +89,8 @@ def test_iterative_tv(
 
     # make sure metadata exists
     assert isinstance(metadata, pd.DataFrame)
+    for expected_col in ["iteration", "tv_weight", "negentropy_after_tv", "average_phase_change"]:
+        assert expected_col in metadata.columns
 
     # test correctness by comparing denoised dataset to noise-free
     noisy_error = diffmap_realspace_rms(very_noisy_map, noise_free_map)

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -3,18 +3,13 @@ from __future__ import annotations
 import gemmi
 import numpy as np
 import pandas as pd
-import pytest
-from skimage.data import binary_blobs
-from skimage.restoration import denoise_tv_chambolle
 
 from meteor.iterative import (
-    _complex_derivative_from_iterative_tv,
-    _project_derivative_on_experimental_set,
     iterative_tv_phase_retrieval,
 )
 from meteor.rsmap import Map
-from meteor.tv import TvDenoiseResult
-from meteor.validate import negentropy
+from meteor.testing import rms_between_coefficients
+from meteor.validate import map_negentropy
 
 
 def map_norm(map1: gemmi.Ccp4Map, map2: gemmi.Ccp4Map) -> float:
@@ -22,80 +17,37 @@ def map_norm(map1: gemmi.Ccp4Map, map2: gemmi.Ccp4Map) -> float:
     return float(np.linalg.norm(diff))
 
 
-def simple_tv_function(fourier_array: np.ndarray) -> tuple[np.ndarray, TvDenoiseResult]:
-    weight = 0.0001
-    real_space = np.fft.ifftn(fourier_array).real
-    denoised = denoise_tv_chambolle(real_space, weight=weight)  # type: ignore[no-untyped-call]
-    result = TvDenoiseResult(
-        initial_negentropy=0.0,
-        optimal_tv_weight=weight,
-        optimal_negentropy=1.0,
-        tv_weights_scanned=[weight],
-        negentropy_at_weights=[1.0],
-        map_sampling_used_for_tv=0,
-    )
-    return np.fft.fftn(denoised), result
+def test_IterativeTvDenoiser() -> None:
+    raise NotImplementedError
+
+    # denoiser = _IterativeTvDenoiser(
+    #     cell=noise_free_map.cell,
+    #     spacegroup=noise_free_map.spacegroup,
+    #     convergence_tolerance=0.001,
+    #     max_iterations=1000,
+    # )
+
+    # denoised_derivative, _ = denoiser(
+    #     native=noise_free_map.to_structurefactor(),
+    #     initial_derivative=noisy_map.to_structurefactor(),
+    # )
+
+    # noisy_error = rms_between_coefficients(noisy_map, noise_free_map)
+    # denoised_error = rms_between_coefficients(denoised_derivative, noise_free_map)
+
+    # # insist on 5% improvement
+    # assert 1.05 * noisy_error < denoised_error
 
 
-def normalized_rms(x: np.ndarray, y: np.ndarray) -> float:
-    normalized_x = x / x.mean()
-    normalized_y = y / y.mean()
-    return float(np.linalg.norm(normalized_x - normalized_y))
-
-
-@pytest.mark.parametrize("scalar", [0.01, 1.0, 2.0, 100.0])
-def test_projected_derivative(scalar: float, np_rng: np.random.Generator) -> None:
-    n = 16
-    native = np_rng.normal(size=n) + 1j * np_rng.normal(size=n)
-    derivative = np_rng.normal(size=n) + 1j * np_rng.normal(size=n)
-    difference = derivative - native
-
-    # ensure the projection removes a scalar multiple of the native & difference
-    scaled_native = scalar * native
-    scaled_difference = scalar * difference
-    proj_derivative = _project_derivative_on_experimental_set(
-        native=scaled_native,
-        derivative_amplitudes=np.abs(derivative),
-        difference=scaled_difference,
-    )
-    np.testing.assert_allclose(proj_derivative, derivative)
-
-
-def test_complex_derivative_from_iterative_tv(np_rng: np.random.Generator) -> None:
-    test_image = binary_blobs(length=64)  # type: ignore[no-untyped-call]
-
-    constant_image = np.ones_like(test_image) / 2.0
-    constant_image_ft = np.fft.fftn(constant_image)
-
-    test_image_noisy = test_image + 0.2 * np_rng.normal(size=test_image.shape)
-    test_image_noisy_ft = np.fft.fftn(test_image_noisy)
-
-    denoised_derivative, _ = _complex_derivative_from_iterative_tv(
-        native=constant_image_ft,
-        initial_derivative=test_image_noisy_ft,
-        tv_denoise_function=simple_tv_function,
-        convergence_tolerance=0.001,
-        max_iterations=1000,
-    )
-
-    denoised_test_image = np.fft.ifftn(denoised_derivative).real
-
-    noisy_error = normalized_rms(denoised_test_image, test_image)
-    denoised_error = normalized_rms(test_image_noisy, test_image)
-
-    # insist on 5% improvement
-    assert 1.05 * noisy_error < denoised_error
+def test_tv_denoise_complex_difference_sf() -> None:
+    raise NotImplementedError
 
 
 def test_iterative_tv_different_indices(noise_free_map: Map, very_noisy_map: Map) -> None:
     # regression test to make sure we can accept maps with different indices
-    labels = pd.MultiIndex.from_arrays(
-        [
-            (1, 2),
-        ]
-        * 3,
-        names=("H", "K", "L"),
-    )
+    hkl = [(1, 2),] * 3,
+    labels = pd.MultiIndex.from_arrays(hkl, names=("H", "K", "L"))
+    
     n = len(very_noisy_map)
     very_noisy_map.drop(labels, inplace=True)
     assert len(very_noisy_map) == n - 2
@@ -127,16 +79,11 @@ def test_iterative_tv(noise_free_map: Map, very_noisy_map: Map) -> None:
     assert isinstance(metadata, pd.DataFrame)
 
     # test correctness by comparing denoised dataset to noise-free
-    map_sampling = 3
-    noise_free_density = noise_free_map.to_ccp4_map(map_sampling=map_sampling)
-    noisy_density = very_noisy_map.to_ccp4_map(map_sampling=3)
-    denoised_density = denoised_map.to_ccp4_map(map_sampling=3)
-
-    noisy_error = map_norm(noisy_density, noise_free_density)
-    denoised_error = map_norm(denoised_density, noise_free_density)
+    noisy_error = rms_between_coefficients(very_noisy_map, noise_free_map)
+    denoised_error = rms_between_coefficients(denoised_map, noise_free_map)
 
     # insist on 1% or better improvement
     assert 1.01 * denoised_error < noisy_error
 
     # insist that the negentropy improves after denoising
-    assert negentropy(np.array(denoised_density.grid)) > negentropy(np.array(noisy_density.grid))
+    assert map_negentropy(denoised_map) > map_negentropy(very_noisy_map)

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -8,7 +8,7 @@ from meteor.iterative import (
     iterative_tv_phase_retrieval,
 )
 from meteor.rsmap import Map
-from meteor.testing import rms_between_coefficients
+from meteor.testing import diffmap_realspace_rms
 from meteor.validate import map_negentropy
 
 
@@ -45,9 +45,14 @@ def test_tv_denoise_complex_difference_sf() -> None:
 
 def test_iterative_tv_different_indices(noise_free_map: Map, very_noisy_map: Map) -> None:
     # regression test to make sure we can accept maps with different indices
-    hkl = [(1, 2),] * 3,
-    labels = pd.MultiIndex.from_arrays(hkl, names=("H", "K", "L"))
-    
+    labels = pd.MultiIndex.from_arrays(
+        [
+            (1, 2),
+        ]
+        * 3,
+        names=("H", "K", "L"),
+    )
+
     n = len(very_noisy_map)
     very_noisy_map.drop(labels, inplace=True)
     assert len(very_noisy_map) == n - 2
@@ -79,8 +84,8 @@ def test_iterative_tv(noise_free_map: Map, very_noisy_map: Map) -> None:
     assert isinstance(metadata, pd.DataFrame)
 
     # test correctness by comparing denoised dataset to noise-free
-    noisy_error = rms_between_coefficients(very_noisy_map, noise_free_map)
-    denoised_error = rms_between_coefficients(denoised_map, noise_free_map)
+    noisy_error = diffmap_realspace_rms(very_noisy_map, noise_free_map)
+    denoised_error = diffmap_realspace_rms(denoised_map, noise_free_map)
 
     # insist on 1% or better improvement
     assert 1.01 * denoised_error < noisy_error

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -113,6 +113,10 @@ def test_iterative_tv_denoiser(
     # insist on 1% or better improvement
     assert 1.01 * denoised_error < noisy_error
 
-    # insist that the negentropy and phase change decrease at every iteration
-    assert (metadata["negentropy_after_tv"].diff()[1:] >= 0).all()
-    assert (metadata["average_phase_change"].diff()[1:] <= 0).all()
+    # insist that the negentropy and phase change decrease (or stay approx same) at every iteration
+    epsilon = 0.001
+    negentropy_change = metadata["negentropy_after_tv"].diff().values[1:]
+    assert (negentropy_change >= -epsilon).all()
+
+    phase_change_change = metadata["average_phase_change"].diff().values[1:]
+    assert (phase_change_change <= epsilon).all()

--- a/test/unit/test_rsmap.py
+++ b/test/unit/test_rsmap.py
@@ -8,7 +8,7 @@ import reciprocalspaceship as rs
 
 from meteor.rsmap import Map, MapMutabilityError, MissingUncertaintiesError, _assert_is_map
 from meteor.testing import assert_phases_allclose
-from meteor.utils import filter_common_indices, ShapeMismatchError
+from meteor.utils import ShapeMismatchError, filter_common_indices
 
 
 def test_assert_is_map(noise_free_map: Map) -> None:
@@ -296,7 +296,7 @@ def from_structurefactor_dataseries(noise_free_map: Map) -> None:
 def from_structurefactor_numpy(noise_free_map: Map) -> None:
     sf_numpy = noise_free_map.to_structurefactor().to_numpy()
     assert isinstance(sf_numpy, np.ndarray)
-    
+
     map2 = Map.from_structurefactor(sf_numpy, index=noise_free_map.index)
     pd.testing.assert_frame_equal(noise_free_map, map2)
 

--- a/test/unit/test_rsmap.py
+++ b/test/unit/test_rsmap.py
@@ -6,22 +6,22 @@ import pandas as pd
 import pytest
 import reciprocalspaceship as rs
 
-from meteor.rsmap import Map, MapMutabilityError, MissingUncertaintiesError, _assert_is_map
+from meteor.rsmap import Map, MapMutabilityError, MissingUncertaintiesError, assert_is_map
 from meteor.testing import assert_phases_allclose
 from meteor.utils import ShapeMismatchError, filter_common_indices
 
 
-def test_assert_is_map(noise_free_map: Map) -> None:
-    _assert_is_map(noise_free_map, require_uncertainties=True)  # should work
+def testassert_is_map(noise_free_map: Map) -> None:
+    assert_is_map(noise_free_map, require_uncertainties=True)  # should work
 
     del noise_free_map["SIGF"]
-    _assert_is_map(noise_free_map, require_uncertainties=False)  # should work
+    assert_is_map(noise_free_map, require_uncertainties=False)  # should work
     with pytest.raises(MissingUncertaintiesError):
-        _assert_is_map(noise_free_map, require_uncertainties=True)
+        assert_is_map(noise_free_map, require_uncertainties=True)
 
     not_a_map = rs.DataSet(noise_free_map)
     with pytest.raises(TypeError):
-        _assert_is_map(not_a_map, require_uncertainties=False)
+        assert_is_map(not_a_map, require_uncertainties=False)
 
 
 def test_initialization_leaves_input_unmodified(noise_free_map: Map) -> None:

--- a/test/unit/test_rsmap.py
+++ b/test/unit/test_rsmap.py
@@ -46,6 +46,18 @@ def test_amplitude_and_phase_required(noise_free_map: Map) -> None:
         Map(ds)
 
 
+def test_column_name_properties(random_difference_map: Map) -> None:
+    assert random_difference_map.amplitude_column_name == "F"
+    assert random_difference_map.phase_column_name == "PHI"
+    assert random_difference_map.uncertainties_column_name == "SIGF"
+
+    # this tests if we ask for the column with no uncertainties
+    del random_difference_map["SIGF"]
+    assert not random_difference_map.has_uncertainties
+    with pytest.raises(AttributeError):
+        _ = random_difference_map.uncertainties_column_name
+
+
 def test_loc_indexing(random_difference_map: Map) -> None:
     ds = rs.DataSet(random_difference_map).rename(columns={"F": "amps", "PHI": "phases"})
     non_std_map = Map(ds, amplitude_column="amps", phase_column="phases")

--- a/test/unit/test_testing.py
+++ b/test/unit/test_testing.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from meteor import testing as mt
+from meteor.rsmap import Map
 
 
 def test_map_columns_smoke() -> None:
@@ -19,6 +20,19 @@ def test_phases_allclose() -> None:
 
     with pytest.raises(AssertionError):
         mt.assert_phases_allclose(close1, far)
+
+
+def test_diffmap_realspace_rms(noise_free_map: Map) -> None:
+    assert mt.diffmap_realspace_rms(noise_free_map, noise_free_map) == 0.0
+
+    map2 = noise_free_map.copy()
+    map2 += 1
+    map3 = noise_free_map.copy()
+    map3 += 2
+
+    dist12 = mt.diffmap_realspace_rms(noise_free_map, map2)
+    dist13 = mt.diffmap_realspace_rms(noise_free_map, map3)
+    assert dist13 > dist12
 
 
 def test_single_carbon_structure_smoke() -> None:

--- a/test/unit/test_tv.py
+++ b/test/unit/test_tv.py
@@ -10,7 +10,7 @@ import pytest
 
 from meteor import tv
 from meteor.rsmap import Map
-from meteor.testing import rms_between_coefficients
+from meteor.testing import diffmap_realspace_rms
 from meteor.validate import map_negentropy
 
 DEFAULT_WEIGHTS_TO_SCAN = np.logspace(-2, 0, 25)
@@ -88,7 +88,7 @@ def test_tv_denoise_map(
     noisy_map: Map,
 ) -> None:
     def rms_to_noise_free(test_map: Map) -> float:
-        return rms_between_coefficients(test_map, noise_free_map)
+        return diffmap_realspace_rms(test_map, noise_free_map)
 
     # Normally, the `tv_denoise_difference_map` function only returns the best result -- since we
     # know the ground truth, work around this to test all possible results.

--- a/test/unit/test_tv.py
+++ b/test/unit/test_tv.py
@@ -134,11 +134,11 @@ def test_tv_denoise_map(
     )
 
 
-def test_final_map_has_reported_negentropy(random_difference_map: Map) -> None:
+def test_final_map_has_reported_negentropy(noisy_map: Map) -> None:
     # regression test -- previously the written map had different indices --> discrepency
     weight = 0.01
     output_map, metadata = tv.tv_denoise_difference_map(
-        random_difference_map,
+        noisy_map,
         weights_to_scan=[weight],
         full_output=True,
     )

--- a/test/unit/test_tv.py
+++ b/test/unit/test_tv.py
@@ -10,6 +10,7 @@ import pytest
 
 from meteor import tv
 from meteor.rsmap import Map
+from meteor.validate import map_negentropy
 
 DEFAULT_WEIGHTS_TO_SCAN = np.logspace(-2, 0, 25)
 
@@ -131,3 +132,16 @@ def test_tv_denoise_map(
     np.testing.assert_allclose(
         result.optimal_tv_weight, best_weight, rtol=0.5, err_msg="opt weight"
     )
+
+
+def test_final_map_has_reported_negentropy(random_difference_map: Map) -> None:
+    # regression test -- previously the written map had different indices --> discrepency
+    weight = 0.01
+    output_map, metadata = tv.tv_denoise_difference_map(
+        random_difference_map,
+        weights_to_scan=[weight],
+        full_output=True,
+    )
+    actual_negentropy = map_negentropy(output_map)
+    assert np.isclose(actual_negentropy, metadata.optimal_negentropy), "final/metadata mismatch"
+    assert np.isclose(actual_negentropy, metadata.negentropy_at_weights[-1]), "final/optimizer"

--- a/test/unit/test_tv.py
+++ b/test/unit/test_tv.py
@@ -10,21 +10,10 @@ import pytest
 
 from meteor import tv
 from meteor.rsmap import Map
+from meteor.testing import rms_between_coefficients
 from meteor.validate import map_negentropy
 
 DEFAULT_WEIGHTS_TO_SCAN = np.logspace(-2, 0, 25)
-
-
-def rms_between_coefficients(map1: Map, map2: Map) -> float:
-    map_sampling = 3
-    map1_array = np.array(map1.to_ccp4_map(map_sampling=map_sampling).grid)
-    map2_array = np.array(map2.to_ccp4_map(map_sampling=map_sampling).grid)
-
-    # standardize
-    map1_array /= map1_array.std()
-    map2_array /= map2_array.std()
-
-    return float(np.linalg.norm(map2_array - map1_array))
 
 
 def test_tv_denoise_result(tv_denoise_result_source_data: dict) -> None:

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-import reciprocalspaceship as rs
-from pandas import testing as pdt
 
 from meteor import utils
 from meteor.rsmap import Map
@@ -102,26 +100,3 @@ def test_average_phase_diff_in_degrees_shape_mismatch() -> None:
     arr2 = np.ones(3)
     with pytest.raises(utils.ShapeMismatchError):
         utils.average_phase_diff_in_degrees(arr1, arr2)
-
-
-def test_complex_array_to_rs_dataseries() -> None:
-    carray = np.array([1.0, 0.0, -1.0, 0.0]) + 1j * np.array([0.0, 1.0, 0.0, -1.0])
-    index = pd.Index(np.arange(4))
-
-    expected_amp = rs.DataSeries(np.ones(4), index=index, name="F").astype(
-        rs.StructureFactorAmplitudeDtype(),
-    )
-    expected_phase = rs.DataSeries([0.0, 90.0, 180.0, -90.0], index=index, name="PHI").astype(
-        rs.PhaseDtype(),
-    )
-
-    amp, phase = utils.complex_array_to_rs_dataseries(carray, index=index)
-    pdt.assert_series_equal(amp, expected_amp)
-    pdt.assert_series_equal(phase, expected_phase)
-
-
-def test_complex_array_to_rs_dataseries_index_mismatch() -> None:
-    carray = np.array([1.0]) + 1j * np.array([1.0])
-    index = pd.Index(np.arange(2))
-    with pytest.raises(utils.ShapeMismatchError):
-        utils.complex_array_to_rs_dataseries(carray, index=index)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+import reciprocalspaceship as rs
 
 from meteor import utils
 from meteor.rsmap import Map
@@ -100,3 +101,17 @@ def test_average_phase_diff_in_degrees_shape_mismatch() -> None:
     arr2 = np.ones(3)
     with pytest.raises(utils.ShapeMismatchError):
         utils.average_phase_diff_in_degrees(arr1, arr2)
+
+
+def test_average_phase_diff_in_degrees_dataseries() -> None:
+    ser1 = rs.DataSeries(np.ones(2), index=np.arange(2))
+    ser2 = rs.DataSeries(np.ones(3), index=np.arange(3))
+    result = utils.average_phase_diff_in_degrees(ser1, ser2)
+    assert np.allclose(result, 0.0)
+
+
+def test_average_phase_diff_in_degrees_mixed_types() -> None:
+    ser1 = np.ones(3)
+    ser2 = rs.DataSeries(np.ones(3), index=np.arange(3))
+    result = utils.average_phase_diff_in_degrees(ser1, ser2)
+    assert np.allclose(result, 0.0)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,3 +1,4 @@
+import gemmi
 import numpy as np
 import pandas as pd
 import pytest
@@ -10,6 +11,21 @@ from meteor.testing import MapColumns
 
 def omit_nones_in_list(input_list: list) -> list:
     return [x for x in input_list if x]
+
+
+def test_assert_isomorphous(random_difference_map: Map) -> None:
+    utils.assert_isomorphous(derivative=random_difference_map, native=random_difference_map)
+
+    different_map = random_difference_map.copy()
+    different_map.spacegroup = gemmi.SpaceGroup(141)  # I41
+    assert random_difference_map.spacegroup != gemmi.SpaceGroup(141)
+    with pytest.raises(utils.NotIsomorphousError):
+        utils.assert_isomorphous(derivative=random_difference_map, native=different_map)
+
+    different_map = random_difference_map.copy()
+    different_map.cell = gemmi.UnitCell(*[100.0, 1.0, 1.0, 90.0, 90.0, 90.0])
+    with pytest.raises(utils.NotIsomorphousError):
+        utils.assert_isomorphous(derivative=random_difference_map, native=different_map)
 
 
 def test_filter_common_indices() -> None:

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 from meteor import validate
+from meteor.rsmap import Map
 
 NP_RNG = np.random.default_rng()
 
@@ -32,6 +33,10 @@ def test_negentropy_uniform() -> None:
 def test_negentropy_zero() -> None:
     negentropy = validate.negentropy(np.zeros(100))
     assert negentropy == -np.inf
+
+
+def test_map_negentropy(noise_free_map: Map, very_noisy_map: Map) -> None:
+    assert validate.map_negentropy(noise_free_map) > validate.map_negentropy(very_noisy_map)
 
 
 def test_negentropy_maximizer_explicit() -> None:


### PR DESCRIPTION
@alisiafadini noticed that the final reported negentropy from a script run was higher than if re-computed from the final written MTZ, issue #57.

We discovered this is because the negentropy values reported during algorithm interactions include reflections that are filled up to the highest resolution, while the final written MTZ retains exactly the same HLK indices as the input MTZ.

We elected to report an MTZ that includes these filled reflections, but more work is needed to understand this behavior in detail, see #58.