### PR TITLE
platform safe type comparison

### DIFF
--- a/test/unit/test_rsmap.py
+++ b/test/unit/test_rsmap.py
@@ -97,14 +97,14 @@ def test_filter_common_indices_with_maps(noise_free_map: Map) -> None:
 
 def test_verify_type(noise_free_map: Map) -> None:
     dataseries = rs.DataSeries([1, 2, 3])
-    assert dataseries.dtype == int
+    assert np.issubdtype(dataseries.dtype, np.integer)
     noise_free_map._verify_type("foo", [int], dataseries, fix=False, cast_fix_to=int)
 
     with pytest.raises(AssertionError):
         noise_free_map._verify_type("foo", [float], dataseries, fix=False, cast_fix_to=float)
 
     output = noise_free_map._verify_type("foo", [float], dataseries, fix=True, cast_fix_to=float)
-    assert output.dtype == float
+    assert np.issubdtype(output.dtype, np.floating)
 
 
 @pytest.mark.parametrize("fix", [False, True])


### PR DESCRIPTION
Our code was breaking on a windows build:
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1070694&view=logs&j=53c3d5f4-e7c7-5b53-4b94-211701b2ba17&t=8f042650-8479-5761-7a4a-8d021c0bb2de

It seems type checking can be platform-dependent; this PR addresses that (I hope!)