### PR TITLE
custom phase input as a general example

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -35,5 +35,5 @@ jobs:
     
     - name: Ensure notebooks complete without errors with pytest and nbmake
       run: |
-        pip install '.[tests]'
+        pip install '.[all]'
         pytest --nbmake examples/*ipynb

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -35,5 +35,5 @@ jobs:
     
     - name: Ensure notebooks complete without errors with pytest and nbmake
       run: |
-        pip install '.[all]'
+        pip install '.[tests,notebooks]'
         pytest --nbmake examples/*ipynb

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,39 @@
+name: run-examples
+
+on:
+  pull_request:
+  workflow_call:
+    inputs:
+      job:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ${{ fromJSON(vars.PYTHON_VERSIONS) }}
+    
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.12.1
+      with:
+        access_token: ${{ github.token }}
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+    
+    - name: Ensure notebooks complete without errors with pytest and nbmake
+      run: |
+        pip install '.[tests]'
+        pytest --nbmake examples/*ipynb

--- a/examples/customized_meteor_diffmap.ipynb
+++ b/examples/customized_meteor_diffmap.ipynb
@@ -149,7 +149,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 3. TV denoise the map\n",
+    "### 3. TV denoise the map\n",
     "\n",
     "Finally, the main event, the entreé! Let's improve our _k_-weighted map by TV-denoising it."
    ]
@@ -216,11 +216,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. Write out the results\n",
+    "\n",
+    "Awesome! Now we have a fancy new diffmap, which we probably want to save so we can do something with it. Like fire up Coot and check it out. If you are curious, the PDB ID corresponding to this dataset is `8a6g`, and you can find a copy of the structure as a PDB file in this repository:\n",
+    "\n",
+    "> `../test/data/8a6g.pdb`"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "tv_denosied_map.write_mtz(\"my_denoised_diffmap.mtz\")"
+   ]
   }
  ],
  "metadata": {

--- a/examples/customized_meteor_diffmap.ipynb
+++ b/examples/customized_meteor_diffmap.ipynb
@@ -15,15 +15,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# ruff: noqa: T201\n",
+    "\n",
     "import numpy as np\n",
     "import reciprocalspaceship as rs\n",
+    "from matplotlib import pyplot as plt\n",
     "\n",
+    "from meteor.diffmaps import compute_difference_map, max_negentropy_kweighted_difference_map\n",
     "from meteor.rsmap import Map\n",
-    "from meteor.diffmaps import max_negentropy_kweighted_difference_map, compute_difference_map\n",
     "from meteor.tv import tv_denoise_difference_map\n",
-    "from meteor.validate import map_negentropy\n",
-    "\n",
-    "from matplotlib import pyplot as plt"
+    "from meteor.validate import map_negentropy"
    ]
   },
   {
@@ -132,7 +133,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "optimal k-parameter: 0.01 / negentropy: 0.00127\n"
+      "optimal k-parameter: 0.01, negentropy: 0.00127\n"
      ]
     }
    ],
@@ -142,7 +143,7 @@
     ")\n",
     "kewighted_negentropy = map_negentropy(k_weighted_diffmap)\n",
     "\n",
-    "print(f\"optimal k-parameter: {kweight_parameter} / negentropy: {kewighted_negentropy:.5f}\")"
+    "print(f\"optimal k-parameter: {kweight_parameter}, negentropy: {kewighted_negentropy:.5f}\")"
    ]
   },
   {
@@ -172,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -187,7 +188,7 @@
     }
    ],
    "source": [
-    "plt.figure(figsize=(8,3))\n",
+    "plt.figure(figsize=(8, 3))\n",
     "\n",
     "plt.xlabel(\"TV weight\")\n",
     "plt.ylabel(\"map negentropy\")\n",
@@ -196,8 +197,8 @@
     "# points are not sampled in order of increasing TV weight, so we have to order them\n",
     "sort_order = np.argsort(metadata.tv_weights_scanned)\n",
     "plt.plot(\n",
-    "    np.array(metadata.tv_weights_scanned)[sort_order], \n",
-    "    np.array(metadata.negentropy_at_weights)[sort_order]\n",
+    "    np.array(metadata.tv_weights_scanned)[sort_order],\n",
+    "    np.array(metadata.negentropy_at_weights)[sort_order],\n",
     ")\n",
     "\n",
     "plt.scatter(\n",
@@ -228,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/customized_meteor_diffmap.ipynb
+++ b/examples/customized_meteor_diffmap.ipynb
@@ -1,0 +1,247 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 📺 Denoise a map with custom inputs\n",
+    "\n",
+    "This notebook takes you step by step through the same procedure as used by `meteor.diffmap`, but in a notebook. There is one difference: we assume you've got some pre-computed phases that you want to employ, rather than computing phases from a structural model (CIF/PDB)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import reciprocalspaceship as rs\n",
+    "\n",
+    "from meteor.rsmap import Map\n",
+    "from meteor.diffmaps import max_negentropy_kweighted_difference_map, compute_difference_map\n",
+    "from meteor.tv import tv_denoise_difference_map\n",
+    "from meteor.validate import map_negentropy\n",
+    "\n",
+    "from matplotlib import pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Load the data of interest\n",
+    "\n",
+    "We'll use `scaled-test-data.mtz`, an test/example MTZ provided in this repo. The data come from a real experiment, Fadini _et al._ (**2023**) _J Am Chem Soc_ 145: 15796-15808 (https://doi.org/10.1021/jacs.3c02313), where the authors imaged the cis-trans isomerization of rsEGFP2. The MTZ contains a lot of columns -- we'll ignore most of them and focus on.\n",
+    "\n",
+    "- the amplitudes and phases for a dark reference dataset\n",
+    "- amplitudes for a light-activated dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index(['F_on', 'SIGF_on', 'F_off', 'SIGF_off', 'FC_nochrom', 'PHIC_nochrom',\n",
+      "       'F_on_scaled', 'SIGF_on_scaled', 'F_off_scaled', 'SIGF_off_scaled',\n",
+      "       'F_k', 'SIGF_k', 'PHI_k', 'F_TV', 'PHI_TV', 'SIGF_TV', 'F_itTV',\n",
+      "       'SIGF_itTV', 'PHI_itTV'],\n",
+      "      dtype='object')\n"
+     ]
+    }
+   ],
+   "source": [
+    "# path is relative to where this notebook usually is in the `meteor` repo\n",
+    "mtz_path = \"../test/data/scaled-test-data.mtz\"\n",
+    "mtz_dataset = rs.read_mtz(mtz_path)\n",
+    "\n",
+    "print(mtz_dataset.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll use the same phase column for both the `native` and `derivative` datasets we're comparing, making the maps we compute isomorphous difference maps. Note that's not a requirement, though!\n",
+    "\n",
+    "In this case, the phases were computed _omitting_ the chromophore where isomerization was expected, so the results should not be biased by the starting model at all. This is a nice application of a custom phase calculation. But: the same effect could be achieved by passing a model without the chromophore to `meteor.diffmap` 😊."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "native_map = Map(\n",
+    "    mtz_dataset,\n",
+    "    amplitude_column=\"F_off\",\n",
+    "    phase_column=\"PHIC_nochrom\",\n",
+    "    uncertainty_column=\"SIGF_off\",\n",
+    ")\n",
+    "\n",
+    "derivative_map = Map(\n",
+    "    mtz_dataset,\n",
+    "    amplitude_column=\"F_on\",\n",
+    "    phase_column=\"PHIC_nochrom\",\n",
+    "    uncertainty_column=\"SIGF_on\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "initial negentropy: 0.00114\n"
+     ]
+    }
+   ],
+   "source": [
+    "# for a reference, let's compute a \"vanilla\" difference map to benchmark the initial negentropy\n",
+    "vanilla_isomorphous_diffmap = compute_difference_map(derivative_map, native_map)\n",
+    "initial_negentropy = map_negentropy(vanilla_isomorphous_diffmap)\n",
+    "\n",
+    "print(f\"initial negentropy: {initial_negentropy:.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Compute a _k_-weighted difference map\n",
+    "\n",
+    "Now, we'll compute a _k_-weighted difference map, varying the _k_-parameter to maximize the difference map negentropy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "optimal k-parameter: 0.01 / negentropy: 0.00127\n"
+     ]
+    }
+   ],
+   "source": [
+    "k_weighted_diffmap, kweight_parameter = max_negentropy_kweighted_difference_map(\n",
+    "    derivative_map, native_map\n",
+    ")\n",
+    "kewighted_negentropy = map_negentropy(k_weighted_diffmap)\n",
+    "\n",
+    "print(f\"optimal k-parameter: {kweight_parameter} / negentropy: {kewighted_negentropy:.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3. TV denoise the map\n",
+    "\n",
+    "Finally, the main event, the entreé! Let's improve our _k_-weighted map by TV-denoising it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tv_denosied_map, metadata = tv_denoise_difference_map(k_weighted_diffmap, full_output=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can inspect the run `metadata` to observe the optimization in progress -- the Golden section method should nicely sample the region around the maximum more densely."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAEwCAYAAABVIKJ9AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAABWo0lEQVR4nO3deVxU5f4H8M/swyKLgOybG8rmAmqSuFRqmpWVhrd7Sb3mjbRFvWaaekv7db3ZZl63LJe63dzKlutSUrkGpSCi4pYKggiyyDrADDNzfn+Qk8giIwMHhs/79ZqXM8/5nnO+Z6LhOw/PeR6JIAgCiIiIiIislFTsBIiIiIiIWhILXiIiIiKyaix4iYiIiMiqseAlIiIiIqvGgpeIiIiIrBoLXiIiIiKyaix4iYiIiMiqseAlIiIiIqvGgpeIiIiIrBoLXiIiIiKyaqIXvGvWrEFgYCDUajUiIiJw+PDhBmNzcnLw1FNPISgoCFKpFLNmzao37ssvv0RwcDBUKhWCg4Px1VdftVD2RERERNTWiVrwbtu2DbNmzcLChQuRkpKC6OhojBkzBpmZmfXGa7VauLm5YeHChejTp0+9MYmJiYiJiUFsbCxSU1MRGxuLJ598Er/++mtLXgoRERERtVESQRAEsU4+aNAg9O/fH2vXrjW19e7dG+PHj8eyZcsa3Xf48OHo27cvVqxYUas9JiYGpaWl2Lt3r6ntwQcfhLOzM7Zs2WLR/ImIiIio7ZOLdWKdTofk5GTMnz+/VvuoUaOQkJBw18dNTEzE7Nmza7WNHj26TmF8K61WC61Wa3ptNBpx48YNuLi4QCKR3HUuRERERNQyBEFAWVkZvLy8IJU2PmhBtIK3oKAABoMB7u7utdrd3d2Rm5t718fNzc01+5jLli3DkiVL7vqcRERERCSOrKws+Pj4NBojWsF70+09qIIgNLtX1dxjLliwAHPmzDG9LikpgZ+fH7KysuDg4NCsXIiIiIjI8kpLS+Hr64tOnTrdMVa0gtfV1RUymaxOz2teXl6dHlpzeHh4mH1MlUoFlUpVp93BwYEFLxEREVEb1pSOUtFmaVAqlYiIiEB8fHyt9vj4eERFRd31cQcPHlznmPv27WvWMalhWq0WU6ZMwZQpU2qNgyYiIiJqK0Qd0jBnzhzExsYiMjISgwcPxvr165GZmYm4uDgANUMNsrOz8emnn5r2OXHiBACgvLwc+fn5OHHiBJRKJYKDgwEAL730EoYOHYq33noLjz76KL755hv88MMPOHLkSKtfX0eg1+vxySefAABWr15db085ERERkZhELXhjYmJQWFiIpUuXIicnB6GhodizZw/8/f0B1Cw0cfucvP369TM9T05Oxueffw5/f39kZGQAAKKiorB161YsWrQIixcvRrdu3bBt2zYMGjSo1a6LiIiIiNoOUefhbatKS0vh6OiIkpISjuG9A41GA3t7ewA1ve52dnYiZ0REREQdgTn1muizNFD7YTQKSEsrQFFRFRwdVdDrjdi+PdW0/b77tmDy5Ajce683wsLcIJVyDmMiIiISHwteapKEhGysXpeK8xnFKCqqQm5mGSrKqwGZzhSTdO4Gjs3+CTJIMGKEH/6x6B44OqpQVFQFZ2c1QkJcWQQTERFRq2PBS3eUkJCNeYuPoNJRBodgB1z4tggVlXrIbGVQd3WE5mRNnOtYL1Scr0Llb2X48UAmkk5cRxcPOyht5VDKpQgKcMLMuD6IivIW94KIiIioQxFtWjJqm4xGAadO5ePQoSycOpUPvd6I1etSUekoQ/hDvrhyshBlJZWQKKSw7+sMpxFdTPsqPdRwuq8LbHp0giAIKK3WoUJmRN/J3REwxhvnNRWYt/gIEhKyRbxCIiIi6mh401o9OupNa7cOW9DpjVDKpXB3VOPytTKETAiARqdHSkoeZB5qyB0UkEglEAQBxspSAIDUpua9EqqNKDtRjKpMDWwgxbDJPdHZ1x6CIODkrkz0srfFp5vGcHgDERER3TXetEZmu3XYQuAYb9i5qqEpqMLJ77JQqDBCpqlEud4Ada8/fqBufleS2jjUrHIiCIBEAolSBseBLnAc6AJjlQHXNFo4C3aQSCTwj3TDub3ZSEsrQFiYm1iXS0RERB0IC16C0SiYhi30edgPEokEWr0BNxQChKjO6CQIKNcbAAC6rAoUp9yAvqQanR/wgMpDbTqOAACCAH2xDvqiaqh8bCBVy3AdBuiyihHs6QB7FxV0eiOKiqrEuVgiIiLqcFjwEtLSCnA+oxiBY7whADiXU4qckircHOsi6IzQZVciYqA7zhwqQOWVMkgMUmhOFUPh0hnFBzYAkMB5xDQIEhlKj92AJq0EChc5vKI8IOlhj6KKavyafgN+ahWUcimcndWNZERERERkOSx4CUVFVdDpjbBzVePC9XJcK6npfXW0kcPHyRb6axVIOHAFl0uN8At3QUFGOcoKamZjEAxaaE7uAQDYBk2qmaXhQhkEAPY2aoQEucDezw5pOaUoq9LjckUVuvR1hH93J/EumIiIiDoUztJAcHZWQymXIiO7DNnFlQCAMG8HRPp3hoejGvZOanh72iNQoUT5mVK4udjA1kYOQ4UBmrMlpuMU7LkGTVoJoDPCyUEFN187qOwVUEkk6KFUweZGNSAIyLMFxv37CJKv3ABQd2YIo5H3URIREZHlsIeXEBLiCo+ejjhdWQVIJOjmZocunWqGHAiCgCtJ+Yjs0wWbNzyIs2cL66y0tnx5zXEie3U2rbRWVqbD2vUncX5vtmnGh4hAJ9w3pBs2pGUj80YFJq5LxPge7sg5cB2/ZZSY4jhfLxEREVkSpyWrR0ebluxqUQXGvn8YpTo9lGV6hHo7opOrGuWFWlxJyoe62IDlbwyptwDVaDSwt7cHAJSXl8POzs607daliG9daa20qhqvf5OGnSk18/HKK43o5WYPF3dbaAqqkHGHcxIRERGZU6+x4K1HRyp4K3UGPLE2AWdyShHgaAOPc5W4mP5Hb2uvQCfMeLbh3tbGCt7GGI0CHozbg98cBQgyCWQSCXq628PLyYbz9RIREdEdcR5eahJBEPDyF6k4k1MKFzsl/vvcYHg6qOvtlbW0tLQC3DhXgrDRnsgyVKOoohpnc8sgk0rg7qDmfL1ERERkMSx4O7A1By5h18kcKGQSrP1LBLydbACgVQrMmzNDOHexhatcgt/yypFVVIlzuWVwtFFwvl4iIiKyGBa8HdQPZ67jnX3nAQBLHgnFwMDOd3UcGxsbpKenm5431c2ZITQFVXD0tEX3LvYoqaxGaZUeaddK0VWh5Hy9REREZBGclqwD+u16GWZtOwFBAP5yjx+eGuR318eSSqUICAhAQEAApNKm/ziFhLgiKMAJGUn5EAQBUokEIV4OkEklKK6sxrnLxegV6ISQENe7zo2IiIgIYMHb4ZRUVGP6p0ko1+oxMLAzXns4RJQ8pFIJZsb1gbrYgJO7MlGcUwElJPBVKQEAFZ3lGPVkd96wRkRERM3GgrcD0RuMeH7LcWQUVsDbyQZr/9wfClnzfgR0Oh1efvllvPzyy9DpdGbtGxXljeVvDEGQnS2u7M1GyuaLKPsxD66VAKQSbDiTjXKtvln5EREREXFasnpY67Rkb+4+g48Op8NGIcOXz0Uh2Kv513a305Ld6vb5en27OuKhfx9BdnElJkb44O2JfZqdJxEREVkXc+o19vB2EF8mX8VHh2tuLntnYh+LFLuWIpVKEBbmhqFDfREW5gYnOyXej+kLqQTYkXwVu0/miJ0iERERtWMseDuAE1nFWPDVKQDAC/d1x0PhniJndGcDAztjxvDuAIAFO08iu7hS5IyIiIiovWLBa+XySqvw7H+SoNMb8UBvd8x+oKfYKTXZSw/0QB9fJ5RW6TFn2wkYjBx9Q0REROZjwWvFqqoN+Nt/knG9VIseXezxfkyfdjXrgUImxQcxfWGnlOHX9BtYd/CS2CkRERFRO8SC10oJgoCFX53GiaxiONoo8PHkSHRSK8ROy2wBrnZ4/ZGaqdPej7+A1KxicRMiIiKidocFr5Xa+HMGvjx+FVIJsOqpfvB3MX/2hLZiQoQPHgr3hN4o4KWtKdBwqjIiIiIyAwteK3TktwK8ufsMAGDhQ8GI7uHWYueysbHB6dOncfr0abOWFjaHRCLBP8eHwctRjYzCCiz5X1qLnIeIiIisEwteK5NRoMHMz4/DKABP9PfBX+8NaNHzSaVShISEICQkxKylhc3laKvAezF9IZEA25OuYs8pTlVGRERETcOC14qUa/WY/mkSSiqr0dfXCW8+FgqJpP3cpHYn93R1wYzh3QAA8788iWucqoyIiIiagAWvlTAaBczedgK/5ZXD3UGF9bERUCtkLX5enU6H119/Ha+//rrZSwvfjVkP9EQfH8eaqcq2c6oyIiIiujMWvFZixQ8XEH/mOpRyKT6MjUQXB3WrnLe6uhpLlizBkiVLUF1d3eLnU8ik+GBSP9gqZfjl8g2sP3S5xc9JRERE7RsLXiuw+2QOVv50EQCw7LEw9PV1EjehFnbrVGXv7juPE5lFOHUqH4cOZeHUqXwY2etLREREt5CLnQA1T9q1EszdkQoAeGZIIJ6I8BE5o9YxMcIHB87nYc+pXExamQC7pBJU64xQyqUICnDCzLg+iIryFjtNIiIiagPYw9uOFZZr8bdPk1FZbUB0D1fMH9NL7JRajUQiwXhvV8h0RlTJAUm0C/pN7YGAMd44r6nAvMVHkJCQLXaaRERE1Aaw4G2nqg1GzPjvcWQXVyLAxRar/tQfclnH+c9pNAr4ZGMa7K7XjBsuqNbjRqUOjp62CB/nhyonGdZ8mMrhDURERCR+wbtmzRoEBgZCrVYjIiIChw8fbjT+4MGDiIiIgFqtRteuXbFu3bo6MStWrEBQUBBsbGzg6+uL2bNno6qqqqUuQRRL/3cGv6bfgL1Kjo8nR8LRtv0tG9wcaWkFOJ9RjJ6hLvDvbAsAOHe9DHqDERKJBP6RbjiXXoy0tAKRMyUiIiKxiVrwbtu2DbNmzcLChQuRkpKC6OhojBkzBpmZmfXGp6enY+zYsYiOjkZKSgpeffVVvPjii/jyyy9NMf/9738xf/58vPbaazh79iw2bNiAbdu2YcGCBa11WS3u818z8Z9frkAiAVbE9EX3Lp3ETqnVFRVVQac3ws5Vja5udrBVylBtEJD9+9y89i4q6PRGFBVZ1xcdIiIiMp+oN6299957mDZtGp555hkANT2z33//PdauXYtly5bViV+3bh38/PywYsUKAEDv3r2RlJSEd955B0888QQAIDExEffeey+eeuopAEBAQAD+9Kc/4ejRo61zUS3saPoN/OOb0wCAuaOC8ECwu6j5qNVq03urVrfOVGgA4OyshlIuhaagCo6etvDvbIuzuWXIvFEJH2dblBdqoZRL4ezcejkRERFR2yRaD69Op0NycjJGjRpVq33UqFFISEiod5/ExMQ68aNHj0ZSUpJpDtghQ4YgOTnZVIRdvnwZe/bswUMPPdRgLlqtFqWlpbUebVF2cSWe+ywZeqOAceGeplXHxCSTyTBgwAAMGDAAMlnLL3RxU0iIK4ICnJCRlA9BEODhqIZKLoXOYEROSSWuJOWjV6ATQkJcWy0nIiIiaptEK3gLCgpgMBjg7l67h9Ld3R25ubn17pObm1tvvF6vR0FBzVjNSZMm4Y033sCQIUOgUCjQrVs3jBgxAvPnz28wl2XLlsHR0dH08PX1bebVWV6lzoC/fZqEQo0OwZ4OWD4h3KqWDTaXVCrBzLg+UBcbcHJXJkpzK+HjWNOb+1tWKVTFBsx4tg+k0o77HhEREVEN0W9au71oEwSh0UKuvvhb2w8cOIA333wTa9aswfHjx7Fz507s2rULb7zxRoPHXLBgAUpKSkyPrKysu72cFiEIAl7+IhVp10rhYqfER5MjYatsG1Mo63Q6vP3223j77bdbZWnhW0VFeWP5G0MQZGeLK3uzkfdNNiTVRhiVUjz2bAjn4SUiIiIAIo7hdXV1hUwmq9Obm5eXV6cX9yYPD4964+VyOVxcXAAAixcvRmxsrGlccFhYGDQaDf72t79h4cKFkErr1vgqlQoqlcoSl9Ui1h68hF0ncyCXSrD2LxHwdrIROyWT6upqzJs3DwAwY8YMKJXKVj1/VJQ37rnHC2lpBSgqqsL3Vwvx35PZ+OHaDfz9Dl+eiIiIqGMQrYdXqVQiIiIC8fHxtdrj4+MRFRVV7z6DBw+uE79v3z5ERkZCoaiZlquioqJOUSuTySAIgqk3uD358ex1vP39eQDAkkdDMDCws8gZtT1SqQRhYW4YOtQX88aHwE4pw7ncMuw/nyd2akRERNQGiDqkYc6cOfj444+xceNGnD17FrNnz0ZmZibi4uIA1Aw1ePrpp03xcXFxuHLlCubMmYOzZ89i48aN2LBhA+bOnWuKefjhh7F27Vps3boV6enpiI+Px+LFi/HII4+06k1VlnAxrwwvbT0BQQD+co8f/jzIX+yU2jxHWwX+ck/N+7Rm/yWRsyEiIqK2QNSBoDExMSgsLMTSpUuRk5OD0NBQ7NmzB/7+NQVLTk5OrTl5AwMDsWfPHsyePRurV6+Gl5cXVq5caZqSDAAWLVoEiUSCRYsWITs7G25ubnj44Yfx5ptvtvr1NUdJRTWmf5qMcq0eAwM74x/jQsROqd2YNiQQmxIykHSlCEfTb7BXnIiIqIOTCO3x7/wtrLS0FI6OjigpKYGDg0Orn99gFDB18zEcupAPbycbfPv8vXCxb5tjjDUaDezt7QEA5eXlsLOzEzmjGq9+dQqf/5qJ4UFu2Dx1oNjpEBERkYWZU6+JPksD1fXWd+dw6EI+bBQyrH86os0Wu23Zs0O7QioBDpzPx+nsErHTISIiIhGx4BWZ0Sjg1Kl8HDqUhVOn8vFl8lWsP3QZAPDOxD4I8XIUOcP2yd/FDuPCvQDUzHJBREREHVfbmMy1g0pIyMbqdak4n1EMnd4IiZMCpWH2gAR4fkR3PBTuKXaKd6RWq7F//37T87bkueHd8G3qNew9lYP0Ag0CXdvGcAsiIiJqXezhFUlCQjbmLT6Cc+UVCBjjjeDYbqjo0wmCBFAX6XGPffsozmQyGYYPH47hw4e3uVkwens64L5eXWAUgA/Zy0tERNRhsYe3Eaezi2Ffamxwe1Nu96svRDAK+NeGEyh1l6PnEA9AIsGZ66WoFgTYKWVQ3ajEuvUnETXYm0vjNtOM4d3w07k8fHn8KmY90BMejm2rF5qIiIhaHgveRkxa/yukKtuWObgbAKiRlFlsapJLJQj3cYTOxgbn9mYjLa0AYWFuLXN+C6mursb69esBAH/7299MC4C0FZEBnTEwoDOOZtzAx4cvY9G4YLFTIiIiolbGgrcRno5qyNXNX8b39tVtq6r0KCyqgspeAfy+TSGVooe7PWyVcihdJNDpjSgqqmr2uVuaTqfD888/DwCYMmVKmyt4AeC5Ed1wdNMNfH40EzNHdIezXesuf0xERETiMrvgHT58OP76179i4sSJsLFpfjHYlsXPGdYi8/CeOpWPqTPjETDGG46edXuQywu1UMqlcHbmn98tYXhPNwR7OuBMTik+SczArAd6ip0SERERtSKzb1qLiIjAvHnz4OHhgenTp+OXX35pibysWkiIK4ICnJCRlI/b1/0QBAFXkvLRK9AJISGuImVoXSQSCWaM6AYA2JyQAY1WL3JGRERE1JrMLnjfffddZGdn49NPP0V+fj6GDh2K4OBgvPPOO7h+/XpL5Gh1pFIJZsb1gbrYgJO7MlGcUwG9zoDinAqc3JUJdbEBM57twxvWLGhMqCcCXe1QXFGNLUcz77wDERERWY27mpZMJpPh0Ucfxddff43s7Gw89dRTWLx4MXx9fTF+/Hj89NNPls7T6kRFeWP5G0MQZGeLK3uzkbL5Iq7szUYve1ssf2MIoqK8xU7RqsikEjw7tCsA4OPD6dDqDSJnRERERK2lWTetHT16FJs2bcKWLVvQpUsXTJkyBTk5OXj44Yfx3HPP4Z133rFUnlYpKsob99zjhbS0AhQVVcHZWY2QEFf27LaQx/p74/0fLiC3tApfHc/GpIF+YqdERERErcDsHt68vDy8++67CA0NRXR0NPLz87F161ZkZGRgyZIlWL9+Pb755husW7euJfK1OlKpBGFhbhg61BdhYW4sdluQSi7D9OiaXt4PD12GwdiEiZSJiIio3TO7h9fHxwfdunXDX//6V0yZMgVubnXniR04cCAGDBhgkQSpbVOpVNi1a5fpeVv3p4F+WLX/ItILNNh7Ogfjwr3ETomIiIhamES4fZqAOzh8+DCio6NbKp82obS0FI6OjigpKWmRaclIXO/HX8AHP/6GYE8H7H5xCCS3T5RMREREbZ459ZrZQxpuFrt5eXk4fPgwjhw5gry8vLvLlEgEU6ICYKuU4UxOKQ5eyBc7HSIiImphZhe8paWliI2Nhbe3N4YNG4ahQ4fC29sbf/nLX1BSUtISOVIbVl1djc2bN2Pz5s2orq4WO50mcbZT4k+/37C25sAlkbMhIiKilmZ2wfvMM8/g119/xa5du1BcXIySkhLs2rULSUlJmD59ekvkSG2YTqfD1KlTMXXqVOh0OrHTabJnogOhkElwNP0Gkq/cEDsdIiIiakFmF7y7d+/Gxo0bMXr0aDg4OKBTp04YPXo0PvroI+zevbslciSyOE9HGzzezwcAsGY/e3mJiIismdkFr4uLCxwdHeu0Ozo6wtnZ2SJJEbWGuOHdIJUAP57Lw7ncUrHTISIiohZidsG7aNEizJkzBzk5Oaa23NxcvPzyy1i8eLFFkyNqSYGudhgT5gkAWMuxvERERFbL7GnJ+vXrh4sXL0Kr1cLPr+bGn8zMTKhUKvTo0aNW7PHjxy2XaSvitGRNp9FoYG9vDwAoLy+HnZ2dyBmZ53R2Ccb9+wikEuDA3BHwc7EVOyUiIiJqAnPqNbMXnhg/fvzd5kXU5oR6O2JYTzccvJCPdYcu4Z+PhYmdEhEREVmY2QXva6+91hJ5EIlmxvBuOHghH18kXcWs+3ugi4Na7JSIiIjIgswueG9KTk7G2bNnIZFIEBwcjH79+lkyL2onVCoVtm/fbnreHg0M7IwIf2ckXynChiPpWDC2t9gpERERkQWZPYY3Ly8PkyZNwoEDB+Dk5ARBEFBSUoIRI0Zg69atcHNza6lcWw3H8HY8P569jmmfJMFOKUPC/PvhaKsQOyUiIiJqRIsuLfzCCy+gtLQUaWlpuHHjBoqKinD69GmUlpbixRdfvOukicR0X68u6OXRCRqdAZ8mZoidDhEREVmQ2QXvd999h7Vr16J37z/+7BscHIzVq1dj7969Fk2O2j69Xo8dO3Zgx44d0Ov1Yqdz1yQSCZ4b3g0AsCkhA5U6g8gZERERkaWYXfAajUYoFHX/3KtQKGA0Gi2SFLUfWq0WTz75JJ588klotVqx02mWh8I84dfZFjc0Omw9lil2OkRERGQhZhe89913H1566SVcu3bN1JadnY3Zs2fj/vvvt2hyRK1JLpPib0O7AgA+OnQZOj2/wBEREVkDswveVatWoaysDAEBAejWrRu6d++OwMBAlJWV4d///ndL5EjUaiZE+MCtkwrXSqrwzYlssdMhIiIiCzB7WjJfX18cP34c8fHxOHfuHARBQHBwMB544IGWyI+oVakVMjwzJBDL9p7D2oOX8Hh/H8ikErHTIiIiomYwq+DV6/VQq9U4ceIERo4ciZEjR7ZUXkSi+fM9/li9/yIu52uwLy0XY8I8xU6JiIiImsGsIQ1yuRz+/v4wGHgHO1kve5Uck6MCAABrDlyCmVNVExERURtj9hjeRYsWYcGCBbhx40ZL5EPUJkyJCoBaIcWp7BIcuVggdjpERETUDGYXvCtXrsThw4fh5eWFoKAg9O/fv9bDXGvWrEFgYCDUajUiIiJw+PDhRuMPHjyIiIgIqNVqdO3aFevWrasTU1xcjJkzZ8LT0xNqtRq9e/fGnj17zM6N7kypVGLTpk3YtGkTlEql2OlYjIu9CpMG+AEA1uy/JHI2RERE1Bxm37T26KOPQiKxzE0827Ztw6xZs7BmzRrce++9+PDDDzFmzBicOXMGfn5+deLT09MxduxYTJ8+HZ999hl+/vlnzJgxA25ubnjiiScAADqdDiNHjkSXLl3wxRdfwMfHB1lZWejUqZNFcqbaFAoFpkyZInYaLWL60K747JcrSLxciJTMIvTzcxY7JSIiIroLEkHEAYqDBg1C//79sXbtWlNb7969MX78eCxbtqxO/CuvvIJvv/0WZ8+eNbXFxcUhNTUViYmJAIB169bh7bffxrlz5+pdIKMpzFmbmazb3B2p+CL5KkYGu+OjpyPFToeIiIh+Z069ZvaQhq5du6KwsLBOe3FxMbp27drk4+h0OiQnJ2PUqFG12keNGoWEhIR690lMTKwTP3r0aCQlJaG6uhoA8O2332Lw4MGYOXMm3N3dERoain/+85+80a6F6PV67N69G7t3727XSws3JG5YN0gkQPyZ67hwvUzsdIiIiOgumF3wZmRk1Fs8arVaXL16tcnHKSgogMFggLu7e612d3d35Obm1rtPbm5uvfF6vR4FBTU3Fl2+fBlffPEFDAYD9uzZg0WLFuHdd9/Fm2++2WAuWq0WpaWltR7UNFqtFuPGjcO4cePa/dLC9enexR6jgz0AAOsOcCwvERFRe9TkMbzffvut6fn3338PR0dH02uDwYAff/wRgYGBZidw+3hgQRAaHSNcX/yt7UajEV26dMH69eshk8kQERGBa9eu4e2338Y//vGPeo+5bNkyLFmyxOzcqWOYMaIbvkvLxTep1zB7ZE/4drYVOyUiIiIyQ5ML3vHjxwOoKSwnT55ca5tCoUBAQADefffdJp/Y1dUVMpmsTm9uXl5enV7cmzw8POqNl8vlcHFxAQB4enpCoVBAJpOZYnr37o3c3FzodLp6ZxJYsGAB5syZY3pdWloKX1/fJl8LWbdwHydE93DF4d8K8NHhy1j6aKjYKREREZEZmjykwWg0wmg0ws/PD3l5eabXRqMRWq0W58+fx7hx45p8YqVSiYiICMTHx9dqj4+PR1RUVL37DB48uE78vn37EBkZabpB7d5778XFixdhNBpNMRcuXICnp2eD02apVCo4ODjUehDd6rnh3QAA245lIb/M+oZuEBERWTOzx/Cmp6fD1dXVIiefM2cOPv74Y2zcuBFnz57F7NmzkZmZibi4OAA1Pa9PP/20KT4uLg5XrlzBnDlzcPbsWWzcuBEbNmzA3LlzTTHPPfccCgsL8dJLL+HChQvYvXs3/vnPf2LmzJkWyZk6psFdXdDX1wlavREbf04XOx0iIiIyg9nz8ALAjz/+iB9//NHU03urjRs3Nvk4MTExKCwsxNKlS5GTk4PQ0FDs2bMH/v7+AICcnBxkZmaa4gMDA7Fnzx7Mnj0bq1evhpeXF1auXGmagxcAfH19sW/fPsyePRvh4eHw9vbGSy+9hFdeeeVuLpUIQM1QnhnDu+Fv/0nGZ4lX8NzwbnBQ3920d0RERNS6zJ6Hd8mSJVi6dCkiIyPh6elZ5yayr776yqIJioHz8DadRqOBvb09AKC8vBx2dnYiZ9RyjEYBo1ccwm955Xh5dBBmjugudkpEREQdljn1mtk9vOvWrcPmzZsRGxt71wmS9VAqlVi1apXpuTWTSiV4bng3zNmeik0/p2PakECoFbI770hERESiMnsMr06na/CmMup4FAoFZs6ciZkzZ971ynbtycN9vODtZIOCch22J2WJnQ4RERE1gdkF7zPPPIPPP/+8JXIhavMUMimeHVazouCHBy+j2mC8wx5EREQkNrOHNFRVVWH9+vX44YcfEB4eXqdX77333rNYctT2GQwGHD58GAAQHR1da/5ja/VkpC9W/vgbsosr8b/Ua3i8v4/YKREREVEjzC54T548ib59+wIATp8+XWtbYyukkXWqqqrCiBEjAFj/TWs3qRUyTL03EG9/fx5rD1zC+L7ekEr5s09ERNRWmV3w7t+/vyXyIGpXYgf7Y92BS/gtrxw/nL2OUSEeYqdEREREDTB7DO9NFy9exPfff4/KykoAgJmzmxG1aw5qBWIH18wXvebAJf78ExERtWFmF7yFhYW4//770bNnT4wdOxY5OTkAam5m+/vf/27xBInaqr8OCYRKLsWJrGIkXi4UOx0iIiJqgNkF7+zZs6FQKJCZmQlbW1tTe0xMDL777juLJkfUlrnaqxAzwBcAsGb/JZGzISIiooaYXfDu27cPb731Fnx8at+Z3qNHD1y5csViiRG1B9Oju0ImleDIxQKcvFosdjpERERUD7MLXo1GU6tn96aCggKoVCqLJEXUXvh2tsWjfbwAsJeXiIiorTK74B06dCg+/fRT02uJRAKj0Yi3337bND0VdRwKhQLLly/H8uXLO8RKa/WJG94NAPD9mVxczCsXORsiIiK6nUQw8/byM2fOYPjw4YiIiMBPP/2ERx55BGlpabhx4wZ+/vlndOvWraVybTWlpaVwdHRESUkJHBwcxE6H2oHpnyYh/sx1TIjwwTsT+4idDhERkdUzp14zu4c3ODgYJ0+exMCBAzFy5EhoNBo8/vjjSElJsYpil+huzPi9l/frlGxkF1eKnA0RERHdyuwe3o6APbxNZzAYcPz4cQBA//79O8TSwg350/pfkHi5EA8HuWNiN3c4O6sREuLKVdiIiIhagDn12l0tLVwfiUQCtVoNPz8/3rzWgVRVVWHgwIEAOs7Swg0Z3sUJiZcL8b8zudi/+TzUggRBAU6YGdcHUVHeYqdHRETUYZld8Pbt2xcSSU2P1c3O4ZuvgZqbmGJiYvDhhx9CrVZbKE2iti0hIRuf/jsVsjBbGNRSdB7riS5GGc4n5WPe4iNY/sYQFr1EREQiMXsM71dffYUePXpg/fr1SE1NxYkTJ7B+/XoEBQXh888/x4YNG/DTTz9h0aJFLZEvUZtjNApYvS4VVY4y9O7qBAC4VlIFuy5qhI/zQ5WTDGs+TIXRyNFDREREYjC7h/fNN9/EBx98gNGjR5vawsPD4ePjg8WLF+Po0aOws7PD3//+d7zzzjsWTZaoLUpLK8D5jGIEjvGGQycVbJUyVOgMyLxRga5u9vCPdMO5vdlISytAWJib2OkSERF1OGb38J46dQr+/v512v39/XHq1CkANcMecnJymp8dUTtQVFQFnd4IO1c1JBIJurrWjGPOuFEBjVYPexcVdHojioqqRM6UiIioYzK74O3Vqxf+9a9/QafTmdqqq6vxr3/9C7169QIAZGdnw93d3XJZErVhzs5qKOVSaApqCtounVRwsVNCEICzuWUoK6iCUi6FszPHtBMREYnB7CENq1evxiOPPAIfHx+Eh4dDIpHg5MmTMBgM2LVrFwDg8uXLmDFjhsWTJWqLQkJcERTghPNJ+Qgf5weJRIJeHp3wS/oNlFRW4/wVDfoFOiEkxFXsVImIiDokswveqKgoZGRk4LPPPsOFCxcgCAImTJiAp556Cp06dQIAxMbGWjxRapsUCgVee+010/OOSCqVYGZcH8xbfAQnd2XCP9IN9i4qeCkVyKrSoaKzApPG9OZ8vERERCLhwhP14MITdDcSErKxel0qzmcUQ6c3QiGXQhfpiDIlMDrEHR/GRoqdIhERkdVo0YUnAOA///kPPvzwQ1y+fBmJiYnw9/fH+++/j65du+LRRx+9q6SJ2ruoKG/cc48X0tIKUFRUBWdnNWQuSjyy6md8n3Yd353OxYOhHmKnSURE1OGYfdPa2rVrMWfOHIwZMwZFRUUwGAwAAGdnZ6xYscLS+VEbZzQakZaWhrS0NBiNRrHTEZ1UKkFYmBuGDvVFWJgbgr0c8eywrgCAf3xzGqVV1SJnSERE1PGYXfD++9//xkcffYSFCxdCLv+jgzgyMtI0LRl1HJWVlQgNDUVoaCgqKyvFTqdNeuG+Hgh0tUNemRZv7T0ndjpEREQdjtkFb3p6Ovr161enXaVSQaPRWCQpImuiVsjwz8fCAAD//TUTxzJuiJwRERFRx2J2wRsYGIgTJ07Uad+7dy+Cg4MtkROR1RnczQUxkb4AgPlfnoRWbxA5IyIioo7D7JvWXn75ZcycORNVVVUQBAFHjx7Fli1bsGzZMnz88cctkSORVXh1bG/8eC4Pl/I1WL3/EuaM7Cl2SkRERB2C2QXv1KlTodfrMW/ePFRUVOCpp56Ct7c3PvjgA0yaNKklciSyCo62Crz+SDCe/zwFaw9cxLhwT/R07yR2WkRERFavWfPwFhQUwGg0okuXLpbMSXSch7fpNBoN7O3tAQDl5eWws7MTOaO2TRAETP80CT+czUOEvzN2PDuYC1IQERHdBXPqNbPH8N7K1dXV6opdopYkkUiw9NFQ2CllSL5ShP/+ekXslIiIiKye2QXv9evXERsbCy8vL8jlcshksloP6lgUCgXmzp2LuXPndtilhc3l5WSDeQ/2AgC89d155JRwOjciIqKWZPaQhjFjxiAzMxPPP/88PD09IZHU/nOsNay0xiEN1NIMRgET1iUgJbMYI4PdsT42os7/S0RERNSwFl1a+MiRIzh8+DD69u17t/kRdXgyqQT/ejwc4/59GPFnapYdHhPmKXZaREREVsnsIQ2+vr5oxn1udaxZswaBgYFQq9WIiIjA4cOHG40/ePAgIiIioFar0bVrV6xbt67B2K1bt0IikWD8+PEWy5dqMxqNyMjIQEZGBpcWNlOQRyfEDesGAPjHt2koqeSyw0RERC3B7IJ3xYoVmD9/PjIyMpp98m3btmHWrFlYuHAhUlJSEB0dbRoyUZ/09HSMHTsW0dHRSElJwauvvooXX3wRX375ZZ3YK1euYO7cuYiOjm52ntSwyspKBAYGIjAwkEsL34WZI7qjq5sd8su0+BeXHSYiImoRZo/hdXZ2RkVFBfR6PWxtbevcqHTjRtOXTR00aBD69++PtWvXmtp69+6N8ePHY9myZXXiX3nlFXz77bc4e/asqS0uLg6pqalITEw0tRkMBgwbNgxTp07F4cOHUVxcjK+//rrJeXEMb9NxWrLm+/VyIWLW/wIA2Pa3ezCoq4vIGREREbV9LTqGd8WKFXebVy06nQ7JycmYP39+rfZRo0YhISGh3n0SExMxatSoWm2jR4/Ghg0bUF1dbSq+ly5dCjc3N0ybNu2OQyQAQKvVQqvVml6XlpaaezlEd21QVxf8aaAvthzNwoKvTmHPi9FQKzjjCRERkaWYXfBOnjzZIicuKCiAwWCAu7t7rXZ3d3fk5ubWu09ubm698Xq9HgUFBfD09MTPP/+MDRs24MSJE03OZdmyZViyZInZ10BkKfPH9MYPZ/NwOV+DNfsvYs6oILFTIiIishrNWnjCEm6fikkQhEanZ6ov/mZ7WVkZ/vKXv+Cjjz6Cq6trk3NYsGABSkpKTI+srCwzroCo+RxtFFjySAgAYM2BSzifWyZyRkRERNbD7B5eS3F1dYVMJqvTm5uXl1enF/cmDw+PeuPlcjlcXFyQlpaGjIwMPPzww6btN2cOkMvlOH/+PLp161bnuCqVCiqVqrmXRNQsY0I98EBvd/xw9jrm7zyJL+KiIOOyw0RERM0mWg+vUqlEREQE4uPja7XHx8cjKiqq3n0GDx5cJ37fvn2IjIyEQqFAr169cOrUKZw4ccL0eOSRRzBixAicOHECvr6+LXY9RM0lkUjwxvgQ2KvkSMksxme/cNlhIiIiSxCthxcA5syZg9jYWERGRmLw4MFYv349MjMzERcXB6BmqEF2djY+/fRTADUzMqxatQpz5szB9OnTkZiYiA0bNmDLli0AALVajdDQ0FrncHJyAoA67WQZcrkcM2bMMD2n5vF0tMErDwZh8TdpWP7dOYwMdoeXk43YaREREbVrzapQsrKyIJFI4OPjc1f7x8TEoLCwEEuXLkVOTg5CQ0OxZ88e+Pv7AwBycnJqzckbGBiIPXv2YPbs2Vi9ejW8vLywcuVKPPHEE825DGoGlUqF1atXi52GVfnzIH98feIakq8U4R/fnMZHT0dy2WEiIqJmMHseXr1ejyVLlmDlypUoLy8HANjb2+OFF17Aa6+9Vmde3vaI8/CS2H67XoaxKw+j2iBg9VP98VA4lx0mIiK6lTn1mtljeJ9//nmsX78ey5cvR0pKClJSUrB8+XJs2LABL7zwwl0nTe2TIAjIz89Hfn6+RZec7uh6uHfCc8O7AwBe+zYNJRVcdpiIiOhumd3D6+joiK1bt2LMmDG12vfu3YtJkyahpKTEogmKgT28TceV1lqOVm/A2A8O41K+BpMG+OJfT4SLnRIREVGb0aI9vGq1GgEBAXXaAwICoFQqzT0cETVAJZeZitytx7Lwy+VCkTMiIiJqn8wueGfOnIk33nij1lK8Wq0Wb775Jp5//nmLJkfU0Q0I6IynBvkBAF7deQpV1QaRMyIiImp/zJ6lISUlBT/++CN8fHzQp08fAEBqaip0Oh3uv/9+PP7446bYnTt3Wi5Tog5q/phe+OHMdVwu0GDVTxcxdzSXHSYiIjKH2QWvk5NTnWnAuKADUctxUCuw9NEQxH12HOsOXsJD4Z7o7cmx5URERE1ldsG7adOmlsiDiBrxYKgnRgW7Y9+Z65i/8xR2Psdlh4mIiJpKtKWFicg8Sx8NRSeVHKlZxfg0MUPsdIiIiNqNu1pp7YsvvsD27duRmZkJnU5Xa9vx48ctkhi1D3K5HJMnTzY9p5bj4ajGK2N6YdHXp/H29+cxKsQD3lx2mIiI6I7M7uFduXIlpk6dii5duiAlJQUDBw6Ei4sLLl++XGduXrJ+KpUKmzdvxubNm6FSqcROx+o9NdAPAwKcUaEzYPHXp7nYBxERUROYXfCuWbMG69evx6pVq6BUKjFv3jzEx8fjxRdftIpFJ4jaMqlUgmWPh0Epk+Knc3nYdTJH7JSIiIjaPLML3szMTERFRQEAbGxsUFZWBgCIjY3Fli1bLJsdtXmCIECj0UCj0bC3sZV079IJM0Z0AwAs+V8aiit0d9iDiIioYzO74PXw8EBhYc2KT/7+/vjll18AAOnp6Sx4OqCKigrY29vD3t4eFRUVYqfTYTw3vBu6d7FHQbkO/9xzVux0iIiI2jSzC9777rsP//vf/wAA06ZNw+zZszFy5EjExMTgscces3iCRFSXSi7Dvx4PAwBsT7qKhEsFImdERETUdkkEM7tljUYjjEaj6Y787du348iRI+jevTvi4uKgVCpbJNHWVFpaCkdHR5SUlMDBgRP8N0aj0cDe3h4AUF5eDjs7O5Ez6lgWfX0Kn/2SiQAXW3w3ayjUCpnYKREREbUKc+o1swvejoAFb9Ox4BVXaVU1Rr53ENdLtZgxvBvmPdhL7JSIiIhahTn12l1NnFpVVYWTJ08iLy8PRqOx1rZHHnnkbg5JRHehZtnhUDz7n2SsP3QZ48K9EOzFL2lERES3Mrvg/e677/D000+joKDumEGJRAKDwWCRxIioaUaHeODBEA98l5aLBTtPYueMe7nsMBER0S3Mvmnt+eefx8SJE5GTk2Maz3vzwWKXSBxLHg1BJ7UcqVdLsDkhQ+x0iIiI2hSzC968vDzMmTMH7u7uLZEPtTMymQwTJkzAhAkTIJPxhimxuDuoMX9Mzfjdd/edx9UiThFHRER0k9kF74QJE3DgwIEWSIXaI7VajR07dmDHjh1Qq9Vip9Oh/WmAHwYGdEaFzoBFXHaYiIjIxOxZGioqKjBx4kS4ubkhLCwMCoWi1vYXX3zRogmKgbM0UHt1Ma8cYz84DJ3BiA8m9cWjfb3FTomIiKhFtOi0ZB9//DHi4uJgY2MDFxcXSCR/3BwjkUhw+fLlu8u6DWHBS+3Zyh9/w3vxF+Bip8QPc4bB2a79z41NRER0O3PqNbOHNCxatAhLly5FSUkJMjIykJ6ebnpYQ7FL5tFoNJBIJJBIJNBoNGKnQwDihnVDT3d7FGp0eJPLDhMREZlf8Op0OsTExEAqNXtXImoFSrkUyx4Ph0QCfJF8FT9f5LLDRETUsZldtU6ePBnbtm1riVyIyEIi/J0Re48/AODVr06hqppTBhIRUcdl9sITBoMBy5cvx/fff4/w8PA6N6299957FkuOiO7ey6ODsC/tOq4UVmDFD7+Zpi0jIiLqaMwueE+dOoV+/foBAE6fPl1r2603sBGRuDqpFXhjfCimf5qEjw5fxsN9PBHi5Sh2WkRERK3O7IJ3//79LZEHEbWAkcHuGBvmgT2ncrFg5ynsfC4KchnH3xMRUcfC33xEVu71h2uWHT7JZYeJiKiDYsFLzSKTyTB27FiMHTuWSwu3UV0c1Hh1bG8AwLv7LiDrBpcdJiKijoUFLzWLWq3G7t27sXv3bi4t3IbFRPpiYGBnVFYbsJDLDhMRUQfDgpeoA5BKJVj2eBiUcikOXcjHNyeuiZ0SERFRq2HBS9RBdHOzx4v3dQcALN11Bjc0OpEzIiIiah0seKlZNBoN7OzsYGdnx6WF24G/De2GIPdOuKHR4f92nxE7HSIiolYhesG7Zs0aBAYGQq1WIyIiAocPH240/uDBg4iIiIBarUbXrl2xbt26Wts/+ugjREdHw9nZGc7OznjggQdw9OjRlryEDq+iogIVFbwRqj1QyqX41xNhkEiAncezcfi3fLFTIiIianGiFrzbtm3DrFmzsHDhQqSkpCA6OhpjxoxBZmZmvfHp6ekYO3YsoqOjkZKSgldffRUvvvgivvzyS1PMgQMH8Kc//Qn79+9HYmIi/Pz8MGrUKGRnZ7fWZRG1af38nDF5cAAAYOFXp1Gp47LDRERk3SSCiLdrDxo0CP3798fatWtNbb1798b48eOxbNmyOvGvvPIKvv32W5w9e9bUFhcXh9TUVCQmJtZ7DoPBAGdnZ6xatQpPP/10k/IqLS2Fo6MjSkpK4ODgYOZVdSwajQb29vYAgPLyctjZ2YmcETVFuVaPUe8dxLWSKjw7tCsW/D5tGRERUXthTr0mWg+vTqdDcnIyRo0aVat91KhRSEhIqHefxMTEOvGjR49GUlISqqur692noqIC1dXV6Ny5c4O5aLValJaW1noQWTN7lRxvjA8FAHx8JB1fH8zAoUNZOHUqH0YjpywjIiLrYvbSwpZSUFAAg8EAd3f3Wu3u7u7Izc2td5/c3Nx64/V6PQoKCuDp6Vlnn/nz58Pb2xsPPPBAg7ksW7YMS5YsuYurIGq/7u/tjnu8nPDLtWL8fcdJ2B4vhUouRVCAE2bG9UFUlLfYKRIREVmE6DetSSSSWq8FQajTdqf4+toBYPny5diyZQt27tzZ6KIICxYsQElJiemRlZVlziUQtUsJCdm4sjsbEoMAg70Mbo95I2CMN85rKjBv8REkJHDcOxERWQfRCl5XV1fIZLI6vbl5eXl1enFv8vDwqDdeLpfDxcWlVvs777yDf/7zn9i3bx/Cw8MbzUWlUsHBwaHWg5pGKpVi2LBhGDZsGKRS0b8/URMZjQJWr0uFzk6KIK9OAICMGxUwOsoR9pAvqpxkWPNhKoc3EBGRVRCtQlEqlYiIiEB8fHyt9vj4eERFRdW7z+DBg+vE79u3D5GRkVAoFKa2t99+G2+88Qa+++47REZGWj55MrGxscGBAwdw4MAB2NjYiJ0ONVFaWgHOZxQjcIAbvJxs4GSrgFEAjmcW42hGEdRhjjiTVYK0tAKxUyUiImo2Ubvk5syZg48//hgbN27E2bNnMXv2bGRmZiIuLg5AzVCDW2dWiIuLw5UrVzBnzhycPXsWGzduxIYNGzB37lxTzPLly7Fo0SJs3LgRAQEByM3NRW5uLsrLy1v9+ojaqqKiKuj0Rti5qiGRSBDq5QgPBzWkEkCjM+BqlQ43IjvhjR/P4+CFfBjY00tERO2YaDetAUBMTAwKCwuxdOlS5OTkIDQ0FHv27IG/vz8AICcnp9acvIGBgdizZw9mz56N1atXw8vLCytXrsQTTzxhilmzZg10Oh0mTJhQ61yvvfYaXn/99Va5LqK2ztlZDaVcCk1BFRw9baGSSxHi5YCeBntcL61CVn4FKmDE0dwSHN14FN5ONpgQ4YOJkT7wcbYVO30iIiKziDoPb1vFeXibTqPRICAgAACQkZHBeXjbCaNRQOyUvTivqUD4OL9aN30KgoCTuzLh42SD8If98fWJbJRW6QEAEgkwpLsrYgb4YmSwO1RymViXQEREHZw59RoL3nqw4G06LjzRfiUkZGPe4iOocpLBP9IN9i4qlBdqcSUpH+piA5a/MQRRUd6oqjbg+7RcbDuWhYRLhab9nW0VeKyfD2IG+CLIo5OIV0JERB0RC95mYsHbdCx427eEhGysXpeK8xnF0OmNUMql6BXohBnP1j8P75VCDXYkXcWO5CxcL9Wa2vv4OmHSAF+MC/dEJ7Wizn5ERESWxoK3mVjwNh0L3vbPaBSQllaAoqIqODurERLiCqm04bmwAUBvMOLQb/nYdiwLP57Ng/73m9psFDI8FO6JSQN8EeHv3Oic2kRERM3BgreZWPA2HQteyi/TYufxq9iWlIXL+RpTe1c3O8RE+uLx/j5w66QSMUMiIrJGLHibiQVv07HgpZsEQUDylSJsO5aFXSdzUFltAADIpRLc37sLYgb4YmgPN8hlXKCEiIiajwVvM7HgbToWvFSfsqpq7DqZg63HspCaVWxq93BQY0KED56M9IWfC6c3IyKiu8eCt5lY8DZdZWUlhg4dCgA4dOgQV1ujOs7nlmHbsSzsTLmK4opqU3tUNxfEDPDF6BAPqBWc3oyIiMzDgreZWPASWZ5Wb0D8mevYdiwLRy4W4OYnj4Najsf6eePJAb4I8XIUN0kiImo3WPA2EwteopZ1tagCO5Ku4ovkq8gurjS1h3o7IGaAHx7p4wVHG05vRkREDWPB20wseIlah8Eo4OeLBdh2LAv7zuSi2lDzcaSSSzE2zBMxA3wxKLAzpzcjIqI6WPA2EwvepquoqEBwcDAA4MyZM7C15Y1IdHcKy7X4KiUb25OycOF6uak9wMUWEyN9MSHCB+4OahEzJCKitoQFbzOx4G06ztJAliYIAk5kFWPbsSz8L/UaNLqa6c1kUglGBLnhyUhfjOjVBQpOb0ZE1KGx4G0mFrxNx4KXWpJGq8fuUznYdiwLyVeKTO1unVR4or8PYgb4ItCVP3NERB0RC95mYsHbdCx4qbVczCvD9qSr+DL5Kgo1OlP7wMDOiIn0xdgwT9goOb0ZEVFHwYK3mVjwNh0LXmptOr0RP52rmd7s4IV8GH//BOukkuORvl6IGeCLMG9H3uhGRGTlWPA2EwvepmPBS2LKKanEF0lXsT05C1k3/pjerJdHJ0wa4Ivx/bzhZKsUMUMiImopLHibiQVv07HgpbbAaBSQeLkQ245l4bu0XOj0RgCAUi7F6BAPTBrgi8FdXSCVsteXiMhamFOvyVspJ7JSEonENC0Z/4RMYpFKJbi3uyvu7e6K4godvjlxDVuPZeFsTin+l3oN/0u9Bt/ONpgY4YuJkT7wdOQS2EREHQl7eOvBHl6i9k8QBJzOLsW2pEx8k3INZVo9AEAqAYb2dENMpC/u7+0OpZzTmxERtUcc0tBMLHiJrEulzoC9p2umN/s1/Yap3cVOicf7eyNmgC+6d+kkYoZERGQuFrzNxIKXyHqlF2iwPSkLXyRfRX6Z1tQe4e+MmEhfPBTuCTsVR3sREbV1LHibiQVv01VUVGDAgAEAgGPHjnFpYWo39AYj9p/Px7ZjWdh/Pg+G3+c3s1PK8HAfLzw5wBf9fJ04Np2IqI1iwdtMLHibjrM0kDXIK63CF8evYvuxLGQUVpjae3SxR8wAXzze3wed7Ti9GRFRW8KCt5lY8DYdC16yJoIg4Gj6DWw7loU9p3NQVV0zvZlCJsHIYHfEDPDDkO6ukN02vZnRKCAtrQBFRVVwdlYjJMSVU6AREbUwFrzNxIK36VjwkrUqqazGt6nXsP1YFk5ll5javRzVmBDpi4kRPvDtbIuEhGysXpeK8xnF0OmNUMqlCApwwsy4PoiK8hbxCoiIrBsL3mZiwdt0LHipIzhzrRTbk7LwVUo2SiqrAQASCRDq2gnZv+QDRgFdI91g56qGpqAKGUn5UBcbsPyNISx6iYhaCAveZmLB23QseKkjqao24Pu0XGxPysLPFwtN7QqZBB4OarjYKyGXSiGVAL/tz0FPGzU+Wf8g1EqZiFkTEVknFrzNxIK36VjwUkcVn5CFF1cfhd7PBtV3+BhVyCSwVcphr5LDVimDrUoOO6UMdr//W/u1HLYqGeyU8ka3K2TWtWAGx0ETkbm4tDC1GolEAn9/f9Nzoo5CpQcU6ZUYMMwbJTo9ckqqUKHTQ28UYPj98ftMZ6g2CCiprDYNh7AEpUwKO5UMtkq56d+bBbXd7//WvJbXiqtTUN/cppRBLlIRzXHQzafXG/HNNxdx7VoZvLw64dFHu0POVQTNwi9dzdPW3z8WvNQstra2yMjIEDsNolbn7KyGUi5FRaEWrp62cLVX1dpenFOBjL3ZWP3+CPh3d4JGa0CFTo9yrR4VWgM0Oj0qdAZotHrTNo2u5rlGW7OtXKuvab+5XWuAzlAzc4TOYISuwoiiCssV0Sq51FQs290skGu9/qNYNhXUN3uhbxbctxXVt89ocbuEhGzMW3wElY4yBI7xNo2DPp+Uj3mLj3AcdBN8+OEJ/OudYygo10GQABIBcJ1/EPPnDsCzz/YVO712gV+6mqc9vH8c0lAPDmkgojsxGgXETtmL85oKhI/zq/UXDkEQcHJXJnrZ2+LTTWMs2suh0xtRqTP8XhzrodEZUPH7vzWvawpqU7H8+/ZyU1H9e/wt++iNLfdrQK2Q1ulVvrWg/vlwNoq11fDs6Qi5VAqJBLj5bmWfvAFPlRJx0/tALpNAKpFAJv3jX5kUfzw3tUkgveV1fbHSW2Nv2V8qRT1tbaeHqj4ffngCr7z+M2R+tnDt3xk2ripUFmhRcPwGDJkVeOv1e1n03kGtL10DePOpucR8/ziGt5lY8BJRU9z8oK9yksE/0g32LiqUF2pxpZ39otTpjX8Uyzd7lk290L8Xy7WK69q9zjeL7z96pQ2mleuswc3i+I8iGnUK5tpFNMwqrOW3HqdOsY4GzwMBWP9RKrRqKZx6dIIEt3zpgoDic6VQVxoxd04kZDKpaevN72Y3428djXbzi5ukVtxt2275UoJ642sft75tkNRz3FsO2dQc/8in4XOi3m2/vxAEvLciGVertAgc6Fbni2vG0Xz42Kgwd3YkJNJb3+G6w/hqb7u1/ba4Wttu08B+t48YbDSPBo5fd9Sh+ce//RCCIOAfSxJwpaIKPYZ6mGLtlHJIJWixL/43seBtJha8TVdZWYmhQ4cCAA4dOgQbGxuRMyJqXfX9Ka9XoBNmPNt2/pTX2gRBgFZv/GPIRq0C+Y/np88V4qt96XALd4YAwGAUIAAQhJqCzWgUUHK1Ar17OsPBUfX7uOjfx0gLNb3sN8dLG4SaeMPv2/94DtM+tbYLtcdZE5HlDO7aGbZKOYpzKnBlbzY2rR6JsDA3i5+HN61RqzEajUhKSjI9J+pooqK8cc89Xm36Zo3WJpFIoFbIoFbIGl2S+ZS9HX7cdB6e4XI4etrW2V6cU4Er5wqw7IV7W+SXJVBTnBsF3FZMC3WK6ZqCGXUK5trFc02B3dCxTNsbOn6dY6Le89zcP/n4dfyclAvHEEdIpRLcXrsLBgGlv5UiItwNQb1cfm+s9Q8EQbjl+R/bbvaFmY5p2ib8EVdf223HQr3b6j/nzW2os63+c9583WiOtx1XQO1zlpVqkZFVBjs3dT3dlzX7VRRq4efdCXb2ijq53XbqOtdwu1s3Cbf9F6u9reHjCQ2+aHi/Oj8bTc2jkS+EgiCgSmtAUbEWSjt5vb3T9i4q6PRGFBVVNXygVsKCtxEajQYymazWVFtVVVUwGAwN7mNOrK2tran7X6vVQq/XWyTWxsYGUmnN3bk6nQ7V1Q3f1GJOrFqthkwmqxWr0WhM2299fmtsdXU1dDpdg8dVqVSQy+Vmx+r1emi12gZjlUolFAqF2bEGgwFVVQ3/z6lQKKBUKs2ONRqNqKystEisXC6HSlVzk5QgCKioqLBIrEwmg1qtNr2+9b9pc2KlUmmt3n9zYisqKhr8BSKRSGBra3tXsZWVlY1+Sbv1/+WmxN4syKqqqlBZ2fB73NE+IxqLDQlxRVCAE84dzUHwaM86f06+/EsWgnxsERTkZGpvic8ImQQQjAZU62piZb8/FJLfn6BtfkZsKdZh36oUOLhJYeNZ+69rEqkMmgI9ND8XYuqkfhgzxqfB43bkz4jTp/MRN+cn+I/ygqOHHeSqP/LV66pQnKNB5olCvPV0H4SG1v7SZe5nxE3WVEecPp2PGXOPIHCsLxw9bWHQV8No0AOCDtVaoCS3AjKJDiqVARqNxuzPiDvVEY39nNQhiGz16tVCQECAoFKphP79+wuHDh1qNP7AgQNC//79BZVKJQQGBgpr166tE/PFF18IvXv3FpRKpdC7d29h586dZuVUUlIi4Pcvgra2trW2jR071rStvsetJkyY0GhseXm5KXby5MmNxubl5ZliZ8yY0Whsenq6KXbu3LmNxp4+fdoU+9prrzUae/ToUVPs8uXLG43dv3+/KXbVqlWNxu7atcsUu2nTpkZjt2/fbordvn17o7GbNm0yxe7atavR2FWrVpli9+/f32js8uXLTbFHjx5tNPa1114zxZ4+fbrR2Llz55pi09PTG42dMWOGKTYvL6/R2MmTJ5tiy8vLG42dMGFCrZ/hxmLHjh1bK9bW1rbB2GHDhtWKdXV1bTA2MjKyVqy/v3+DscHBwbVig4ODG4z19/evFRsZGdlgrKura63YYcOGNRjLz4g/HnfzGfHzz1eFrj2nNhrLz4iahzmfEa4DHhY6D9woBPZYL1y7lttoLD8jah72Lp7CXzcdNT1cA3o3/P7yM+KP/84PrxEiHt8hTN34q9D30WcajW2pOqKkpES4E1En6du2bRtmzZqFhQsXIiUlBdHR0RgzZgwyMzPrjU9PT8fYsWMRHR2NlJQUvPrqq3jxxRfx5ZdfmmISExMRExOD2NhYpKamIjY2Fk8++SR+/fXX1rosIiJqoqgob4wf103sNKxO2ZVyGDIr8MrfB3A+3ibSVepRnFMBvc6A4pwKVBQ3/JcE+sOfngyCutiAk7syUVVmuWkSLU3Um9YGDRqE/v37Y+3ataa23r17Y/z48Vi2bFmd+FdeeQXffvstzp49a2qLi4tDamoqEhMTAQAxMTEoLS3F3r17TTEPPvggnJ2dsWXLlibldXMQ9LVr1+Dg4GC1f4owN7ahIQ3u7u4AgOvXr5uun0Ma6sZySIN1D2m4iZ8Rd/fnyqoqLc6cKUBxsRZOTioEB/8xDpqfEY3HbthwEu9+kIzCW+bhdeukxvyXo/Dss335GdGEz4hffrmG9RtO4dLVKtPNp919bTD9r6G45x6veo/Nz4g/Yn/5JQer16Xi7OUC6Kp1UMilCPJ3wvRpYbXeP0sPaSgtLYWXl1fbnqVBp9PB1tYWO3bswGOPPWZqf+mll3DixAkcPHiwzj5Dhw5Fv3798MEHH5javvrqKzz55JOoqKiAQqGAn58fZs+ejdmzZ5ti3n//faxYsQJXrlypNxetVlvrg66kpAR+fn7IysriLA13oNFo4OVV88N87do1Li1MRCQCvd6I3bsvIyenDJ6enfDQQ13Zs2smo1HA2bOFKC6ugpOTGr17u3Tom0/NJcb7V1paCl9fXxQXF8PR0bHRWNFuWisoKIDBYDD1Dt7k7u6O3NzcevfJzc2tN16v16OgoACenp4NxjR0TABYtmwZlixZUqfd19e3qZdDgKnwJSIiImotZWVlbbfgven2CZMFQajTdqf429vNPeaCBQswZ84c02uj0YgbN27AxcWlwf0GDBiAY8eONXhMc1nieDe/6bBn2npY+uesvWvv70dbzF/MnFrj3C15Dksem78DqD5t8TNDTLe/H4IgoKysrEkdbqIVvK6urpDJZHV6XvPy8ur00N7k4eFRb7xcLoeLi0ujMQ0dE6gZ83Vz/NJNTk5OjeYvk8ks+oFiyeM5ODjww85KWPrnrL1r7+9HW8xfzJxa49wteQ5LHpu/A6g+bfEzQ0z1vR936tm9SbQBPkqlEhEREYiPj6/VHh8fj6ioqHr3GTx4cJ34ffv2ITIy0nQzQUMxDR3zbs2cObNNH4+sA38uamvv70dbzF/MnFrj3C15Dkseuy3+bJD4+HNRW3PeD1Fnadi2bRtiY2Oxbt06DB48GOvXr8dHH32EtLQ0+Pv7Y8GCBcjOzsann34KoGZastDQUDz77LOYPn06EhMTERcXhy1btuCJJ54AACQkJGDo0KF488038eijj+Kbb77BokWLcOTIEQwaNEisS20VXBKZiKjj4u8AooaJOoY3JiYGhYWFWLp0KXJychAaGoo9e/bA398fAJCTk1NrTt7AwEDs2bMHs2fPxurVq+Hl5YWVK1eail0AiIqKwtatW7Fo0SIsXrwY3bp1w7Zt26y+2AVqhma89tprdYZnEBGR9ePvAKKGidrDS0RERETU0jhJHxERERFZNRa8RERERGTVWPASERERkVVjwUtEREREVo0FLxERERFZNRa8HVBZWRkGDBiAvn37IiwsDB999JHYKRERUSvJysrC8OHDERwcjPDwcOzYsUPslIhaHKcl64AMBgO0Wi1sbW1RUVGB0NBQHDt2zLQ8MxERWa+cnBxcv34dffv2RV5eHvr374/z58/Dzs5O7NSIWoyoC0+QOGQyGWxtbQEAVVVVMBgM4PceIqKOwdPTE56engCALl26oHPnzrhx4wYLXrJqHNLQBh06dAgPP/wwvLy8IJFI8PXXX9eJWbNmDQIDA6FWqxEREYHDhw+bdY7i4mL06dMHPj4+mDdvHlxdXS2UPRERNUdr/A64KSkpCUajEb6+vs3MmqhtY8HbBmk0GvTp0werVq2qd/u2bdswa9YsLFy4ECkpKYiOjsaYMWNqLcMcERGB0NDQOo9r164BAJycnJCamor09HR8/vnnuH79eqtcGxERNa41fgcAQGFhIZ5++mmsX7++xa+JSGwcw9vGSSQSfPXVVxg/frypbdCgQejfvz/Wrl1rauvduzfGjx+PZcuWmX2O5557Dvfddx8mTpxoiZSJiMhCWup3gFarxciRIzF9+nTExsZaOm2iNoc9vO2MTqdDcnIyRo0aVat91KhRSEhIaNIxrl+/jtLSUgBAaWkpDh06hKCgIIvnSkRElmWJ3wGCIGDKlCm47777WOxSh8Gb1tqZgoICGAwGuLu712p3d3dHbm5uk45x9epVTJs2DYIgQBAEPP/88wgPD2+JdImIyIIs8Tvg559/xrZt2xAeHm4aH/yf//wHYWFhlk6XqM1gwdtOSSSSWq8FQajT1pCIiAicOHGiBbIiIqLW0JzfAUOGDIHRaGyJtIjaLA5paGdcXV0hk8nqfJPPy8ur842fiIisC38HEN0dFrztjFKpREREBOLj42u1x8fHIyoqSqSsiIioNfB3ANHd4ZCGNqi8vBwXL140vU5PT8eJEyfQuXNn+Pn5Yc6cOYiNjUVkZCQGDx6M9evXIzMzE3FxcSJmTURElsDfAUSWx2nJ2qADBw5gxIgRddonT56MzZs3A6iZdHz58uXIyclBaGgo3n//fQwdOrSVMyUiIkvj7wAiy2PBS0RERERWjWN4iYiIiMiqseAlIiIiIqvGgpeIiIiIrBoLXiIiIiKyaix4iYiIiMiqseAlIiIiIqvGgpeIiIiIrBoLXiIiIiKyaix4iYjIZPPmzXBycjJrnylTpmD8+PEtkg8RkSWw4CUiamESiaTRx5gxY6BQKPDZZ5/Vu/+zzz6L8PDwVsk1JiYGFy5csPhxAwICsGLFCosfl4ioKVjwEhG1sJycHNNjxYoVcHBwqNW2detWPPTQQ9i0aVOdfSsrK7F161ZMmzatVXK1sbFBly5dWuVcRESthQUvEVEL8/DwMD0cHR0hkUjqtE2bNg379+9HRkZGrX2/+OILVFVV4S9/+Uu9x46IiMC7775rej1+/HjI5XKUlpYCAHJzcyGRSHD+/HkAgE6nw7x58+Dt7Q07OzsMGjQIBw4cMO1f35CG//u//0OXLl3QqVMnPPPMM5g/fz769u1bJ5d33nkHnp6ecHFxwcyZM1FdXQ0AGD58OK5cuYLZs2eberWJiFoTC14iojZg7Nix8PDwwObNm2u1b9y4EePHj4eLi0u9+w0fPtxUsAqCgMOHD8PZ2RlHjhwBAOzfvx8eHh4ICgoCAEydOhU///wztm7dipMnT2LixIl48MEH8dtvv9V7/P/+979488038dZbbyE5ORl+fn5Yu3Ztnbj9+/fj0qVL2L9/Pz755BNs3rzZdC07d+6Ej48Pli5daurVJiJqTSx4iYjaAJlMhqeffhqbN2+GIAgAgPT0dBw8eLDR4QzDhw/H4cOHYTQacfLkSchkMsTGxpqK4AMHDmDYsGEAgEuXLmHLli3YsWMHoqOj0a1bN8ydOxdDhgypdzgFAPz73//GtGnTMHXqVPTs2RP/+Mc/EBYWVifO2dkZq1atQq9evTBu3Dg89NBD+PHHHwEAnTt3hkwmQ6dOnUy92kRErYkFLxFRGzFt2jRcuXIFP/30E4Ca3l0fHx888MADDe4zdOhQlJWVISUlBQcPHsSwYcMwYsQIHDx4EEDtgvf48eMQBAE9e/aEvb296XHw4EFcunSp3uOfP38eAwcOrNV2+2sACAkJgUwmM7329PREXl6eeW8AEVELkYudABER1ejRoweio6OxadMmjBgxAp988gmmTp0KqbThvglHR0f07dsXBw4cQEJCAu677z5ER0fjxIkT+O2333DhwgUMHz4cAGA0GiGTyZCcnFyrOAUAe3v7Bs9x+5jbmz3Qt1IoFHX2MRqNd7pkIqJWwR5eIqI2ZNq0adi5cye+/PJLXL16FVOnTr3jPsOHD8f+/ftx6NAhDB8+HE5OTggODjbdbNa7d28AQL9+/WAwGJCXl4fu3bvXejQ0zCAoKAhHjx6t1ZaUlGT2dSmVShgMBrP3IyKyBBa8RERtyMSJE6FQKPDss8/i/vvvR0BAwB33GT58OL777jtIJBIEBweb2v773/+ahjMAQM+ePfHnP/8ZTz/9NHbu3In09HQcO3YMb731Fvbs2VPvsV944QVs2LABn3zyCX777Tf83//9H06ePGn2TAsBAQE4dOgQsrOzUVBQYNa+RETNxYKXiKgNsbW1xaRJk1BUVIS//vWvTdpn6NChAIBhw4aZCtFhw4bBYDDUKngBYNOmTXj66afx97//HUFBQXjkkUfw66+/wtfXt95j//nPf8aCBQswd+5c9O/fH+np6ZgyZQrUarVZ17V06VJkZGSgW7ducHNzM2tfIqLmkgj1DcYiIiJqwMiRI+Hh4YH//Oc/YqdCRNQkvGmNiIgaVFFRgXXr1mH06NGQyWTYsmULfvjhB8THx4udGhFRk7GHl4iIGlRZWYmHH34Yx48fh1arRVBQEBYtWoTHH39c7NSIiJqMBS8RERERWTXetEZEREREVo0FLxERERFZNRa8RERERGTVWPASERERkVVjwUtEREREVo0FLxERERFZNRa8RERERGTVWPASERERkVVjwUtEREREVu3/AT5d/gnZhP2LAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(8,3))\n",
+    "\n",
+    "plt.xlabel(\"TV weight\")\n",
+    "plt.ylabel(\"map negentropy\")\n",
+    "plt.xscale(\"log\")\n",
+    "\n",
+    "# points are not sampled in order of increasing TV weight, so we have to order them\n",
+    "sort_order = np.argsort(metadata.tv_weights_scanned)\n",
+    "plt.plot(\n",
+    "    np.array(metadata.tv_weights_scanned)[sort_order], \n",
+    "    np.array(metadata.negentropy_at_weights)[sort_order]\n",
+    ")\n",
+    "\n",
+    "plt.scatter(\n",
+    "    metadata.tv_weights_scanned,\n",
+    "    metadata.negentropy_at_weights,\n",
+    "    edgecolors=\"darkblue\",\n",
+    "    linewidths=1,\n",
+    "    alpha=0.7,\n",
+    ")\n",
+    "\n",
+    "plt.hlines(metadata.initial_negentropy, 0, 0.05, color=\"black\", linestyle=\"dashed\")\n",
+    "plt.vlines(metadata.optimal_tv_weight, -0.01, 0.10, color=\"black\", linestyle=\"dashed\")\n",
+    "plt.ylim([0, 0.10])\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "rstest",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ tests = [
     "pytest-xdist",
     "nbmake",
 ]
+notebooks = [
+    "matplotlib",
+]
 
 [project.scripts]
 "meteor.diffmap" = "meteor.scripts.compute_difference_map:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ tests = [
     "pytest",
     "pytest-cov",
     "pytest-xdist",
+    "nbmake",
 ]
 
 [project.scripts]


### PR DESCRIPTION
@DHekstra was interested in running `meteor.diffmap` but using pre-computed phases rather than those computed from a model.

I actually started extending the CLI (`meteor.diffmap`) to facilitate this, but then decided against it. The logic in the CLI is starting to get complex, and I want to limit it as much as possible to the "normal" use case, guiding non-expert users.

So instead, I thought maybe this would be a great case for a [notebook example](https://github.com/rs-station/meteor/blob/tjlane/intensity-input/examples/customized_meteor_diffmap.ipynb) of how to use the `meteor` library to do more custom things. Here's a proposed notebook. @DHekstra, as a user, I'm curious how your experience/vibes are here.

Aims to resolve #77.
