### PR TITLE
fix bugged TV denoising tests

### DIFF
--- a/meteor/rsmap.py
+++ b/meteor/rsmap.py
@@ -426,6 +426,10 @@ class Map(rs.DataSet):
             uncertainty_column=uncertainty_column,
         )
 
+    def to_3d_numpy_map(self, *, map_sampling: int) -> np.ndarray:
+        realspace_map = self.to_ccp4_map(map_sampling=map_sampling)
+        return np.array(realspace_map.grid)
+
     @classmethod
     @cellify("cell")
     def from_3d_numpy_map(

--- a/meteor/testing.py
+++ b/meteor/testing.py
@@ -9,7 +9,6 @@ import gemmi
 import numpy as np
 
 from .rsmap import Map
-from .settings import MAP_SAMPLING
 
 
 @dataclass
@@ -28,15 +27,11 @@ def assert_phases_allclose(array1: np.ndarray, array2: np.ndarray, atol: float =
         raise AssertionError(msg)
 
 
-def diffmap_realspace_rms(map1: Map, map2: Map) -> float:
-    map1_array = np.array(map1.to_ccp4_map(map_sampling=MAP_SAMPLING).grid)
-    map2_array = np.array(map2.to_ccp4_map(map_sampling=MAP_SAMPLING).grid)
-
-    # standardize
-    map1_array /= map1_array.std()
-    map2_array /= map2_array.std()
-
-    return float(np.linalg.norm(map2_array - map1_array))
+def map_corrcoeff(map1: Map, map2: Map) -> float:
+    map1_np = map1.to_numpy().flatten()
+    map2_np = map2.to_numpy().flatten()
+    rho = np.corrcoef(map1_np, map2_np)
+    return rho[0, 1]
 
 
 def check_test_file_exists(path: Path) -> None:

--- a/meteor/testing.py
+++ b/meteor/testing.py
@@ -9,6 +9,7 @@ import gemmi
 import numpy as np
 
 from .rsmap import Map
+from .settings import MAP_SAMPLING
 
 
 @dataclass
@@ -28,8 +29,8 @@ def assert_phases_allclose(array1: np.ndarray, array2: np.ndarray, atol: float =
 
 
 def map_corrcoeff(map1: Map, map2: Map) -> float:
-    map1_np = map1.to_numpy().flatten()
-    map2_np = map2.to_numpy().flatten()
+    map1_np = map1.to_3d_numpy_map(map_sampling=MAP_SAMPLING).flatten()
+    map2_np = map2.to_3d_numpy_map(map_sampling=MAP_SAMPLING).flatten()
     rho = np.corrcoef(map1_np, map2_np)
     return rho[0, 1]
 

--- a/meteor/tv.py
+++ b/meteor/tv.py
@@ -168,8 +168,7 @@ def tv_denoise_difference_map(
     >>> denoised_map, result = tv_denoise_difference_map(coefficients, full_output=True)
     >>> print(f"Optimal: {result.optimal_tv_weight}, Negentropy: {result.optimal_negentropy}")
     """
-    realspace_map = difference_map.to_ccp4_map(map_sampling=MAP_SAMPLING)
-    realspace_map_array = np.array(realspace_map.grid)
+    realspace_map_array = difference_map.to_3d_numpy_map(map_sampling=MAP_SAMPLING)
 
     def negentropy_objective(tv_weight: float) -> float:
         denoised_map = _tv_denoise_array(map_as_array=realspace_map_array, weight=tv_weight)

--- a/meteor/validate.py
+++ b/meteor/validate.py
@@ -91,8 +91,7 @@ def map_negentropy(map_to_assess: Map, *, tolerance: float = 0.1) -> float:
     ValueError: If the computed negentropy is less than the negative tolerance,
                 indicating potential issues with the computation.
     """
-    realspace_map = map_to_assess.to_ccp4_map(map_sampling=MAP_SAMPLING)
-    realspace_map_array = np.array(realspace_map.grid)
+    realspace_map_array = map_to_assess.to_3d_numpy_map(map_sampling=MAP_SAMPLING)
     return negentropy(realspace_map_array, tolerance=tolerance)
 
 

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -96,12 +96,12 @@ def test_iterative_tv_denoiser_different_indices(
 
 
 def test_iterative_tv_denoiser(
-    noise_free_map: Map, noisy_map: Map, testing_denoiser: IterativeTvDenoiser
+    noise_free_map: Map, very_noisy_map: Map, testing_denoiser: IterativeTvDenoiser
 ) -> None:
     # the test case is the denoising of a difference: between a noisy map and its noise-free origin
     # such a diffmap is ideally totally flat, so should have very low TV
 
-    denoised_map, metadata = testing_denoiser(derivative=noisy_map, native=noise_free_map)
+    denoised_map, metadata = testing_denoiser(derivative=very_noisy_map, native=noise_free_map)
 
     # make sure metadata exists
     assert isinstance(metadata, pd.DataFrame)
@@ -109,7 +109,7 @@ def test_iterative_tv_denoiser(
         assert expected_col in metadata.columns
 
     # test correctness by comparing denoised dataset to noise-free
-    noisy_cc = map_corrcoeff(noisy_map, noise_free_map)
+    noisy_cc = map_corrcoeff(very_noisy_map, noise_free_map)
     denoised_cc = map_corrcoeff(denoised_map, noise_free_map)
 
     # insist on improvement

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -10,7 +10,7 @@ from meteor.iterative import (
     _assert_are_dataseries,
 )
 from meteor.rsmap import Map
-from meteor.testing import diffmap_realspace_rms
+from meteor.testing import map_corrcoeff
 from meteor.tv import TvDenoiseResult
 
 
@@ -109,11 +109,11 @@ def test_iterative_tv_denoiser(
         assert expected_col in metadata.columns
 
     # test correctness by comparing denoised dataset to noise-free
-    noisy_error = diffmap_realspace_rms(very_noisy_map, noise_free_map)
-    denoised_error = diffmap_realspace_rms(denoised_map, noise_free_map)
+    noisy_cc = map_corrcoeff(very_noisy_map, noise_free_map)
+    denoised_cc = map_corrcoeff(denoised_map, noise_free_map)
 
     # insist on improvement
-    assert denoised_error < noisy_error
+    assert denoised_cc > noisy_cc
 
     # insist that the negentropy and phase change decrease (or stay approx same) at every iteration
     negentropy_change = metadata["negentropy_after_tv"].diff().to_numpy()

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -96,12 +96,12 @@ def test_iterative_tv_denoiser_different_indices(
 
 
 def test_iterative_tv_denoiser(
-    noise_free_map: Map, very_noisy_map: Map, testing_denoiser: IterativeTvDenoiser
+    noise_free_map: Map, noisy_map: Map, testing_denoiser: IterativeTvDenoiser
 ) -> None:
     # the test case is the denoising of a difference: between a noisy map and its noise-free origin
     # such a diffmap is ideally totally flat, so should have very low TV
 
-    denoised_map, metadata = testing_denoiser(derivative=very_noisy_map, native=noise_free_map)
+    denoised_map, metadata = testing_denoiser(derivative=noisy_map, native=noise_free_map)
 
     # make sure metadata exists
     assert isinstance(metadata, pd.DataFrame)
@@ -109,7 +109,7 @@ def test_iterative_tv_denoiser(
         assert expected_col in metadata.columns
 
     # test correctness by comparing denoised dataset to noise-free
-    noisy_cc = map_corrcoeff(very_noisy_map, noise_free_map)
+    noisy_cc = map_corrcoeff(noisy_map, noise_free_map)
     denoised_cc = map_corrcoeff(denoised_map, noise_free_map)
 
     # insist on improvement

--- a/test/unit/test_rsmap.py
+++ b/test/unit/test_rsmap.py
@@ -342,9 +342,19 @@ def test_from_ccp4_map(ccp4_map: gemmi.Ccp4Map) -> None:
     assert len(rsmap) > 0
 
 
-def test_from_numpy(noise_free_map: Map) -> None:
+def test_to_3d_numpy(noise_free_map: Map) -> None:
+    array = noise_free_map.to_3d_numpy_map(map_sampling=3)
+    assert array.shape == (30, 30, 30)
+
+    # consistency with gemmi
+    ccp4_map = noise_free_map.to_ccp4_map(map_sampling=3)
+    ccp4_array = np.array(ccp4_map.grid)
+    np.testing.assert_allclose(array, ccp4_array)
+
+
+def test_from_3d_numpy(noise_free_map: Map) -> None:
     _, resolution = noise_free_map.resolution_limits
-    array = np.array(noise_free_map.to_ccp4_map(map_sampling=3).grid)
+    array = noise_free_map.to_3d_numpy_map(map_sampling=3)
     new_map = Map.from_3d_numpy_map(
         array,
         spacegroup=noise_free_map.spacegroup,

--- a/test/unit/test_testing.py
+++ b/test/unit/test_testing.py
@@ -2,13 +2,13 @@ import gemmi
 import numpy as np
 import pytest
 
-from meteor import testing as mt
+from meteor import testing as meteortesting
 from meteor.rsmap import Map
 
 
 def test_map_columns_smoke() -> None:
-    mt.MapColumns(amplitude="amp", phase="phase", uncertainty=None)
-    mt.MapColumns(amplitude="amp", phase="phase", uncertainty="sig")
+    meteortesting.MapColumns(amplitude="amp", phase="phase", uncertainty=None)
+    meteortesting.MapColumns(amplitude="amp", phase="phase", uncertainty="sig")
 
 
 def test_phases_allclose() -> None:
@@ -16,22 +16,22 @@ def test_phases_allclose() -> None:
     close2 = np.array([-0.0001, 90.0, 180.0001, 360.0001, 0.9999])
     far = np.array([0.5, 90.5, 180.0, 360.0, 361.0])
 
-    mt.assert_phases_allclose(close1, close2)
+    meteortesting.assert_phases_allclose(close1, close2)
 
     with pytest.raises(AssertionError):
-        mt.assert_phases_allclose(close1, far)
+        meteortesting.assert_phases_allclose(close1, far)
 
 
 def test_map_corrcoeff(noise_free_map: Map, np_rng: np.random.Generator) -> None:
-    assert mt.map_corrcoeff(noise_free_map, noise_free_map) == 1.0
+    assert meteortesting.map_corrcoeff(noise_free_map, noise_free_map) == 1.0
 
     noisy_map = noise_free_map.copy()
     noisy_map.amplitudes += np_rng.normal(size=len(noise_free_map))
     noisier_map = noise_free_map.copy()
     noisier_map.amplitudes += 10.0 * np_rng.normal(size=len(noise_free_map))
 
-    noisy_cc = mt.map_corrcoeff(noise_free_map, noisy_map)
-    noisier_cc = mt.map_corrcoeff(noise_free_map, noisier_map)
+    noisy_cc = meteortesting.map_corrcoeff(noise_free_map, noisy_map)
+    noisier_cc = meteortesting.map_corrcoeff(noise_free_map, noisier_map)
     assert 1.0 > noisy_cc > noisier_cc > 0.0
 
 
@@ -39,7 +39,7 @@ def test_single_carbon_structure_smoke() -> None:
     carbon_position = (4.0, 5.0, 6.0)
     space_group = gemmi.find_spacegroup_by_name("P212121")
     unit_cell = gemmi.UnitCell(a=9.0, b=10.0, c=11.0, alpha=90, beta=90, gamma=90)
-    structure = mt.single_carbon_structure(carbon_position, space_group, unit_cell)
+    structure = meteortesting.single_carbon_structure(carbon_position, space_group, unit_cell)
     assert isinstance(structure, gemmi.Structure)
 
 
@@ -48,7 +48,7 @@ def single_carbon_density_smoke() -> None:
     space_group = gemmi.find_spacegroup_by_name("P212121")
     unit_cell = gemmi.UnitCell(a=9.0, b=10.0, c=11.0, alpha=90, beta=90, gamma=90)
     high_resolution_limit = 1.0
-    density = mt.single_carbon_density(
+    density = meteortesting.single_carbon_density(
         carbon_position, space_group, unit_cell, high_resolution_limit
     )
     assert isinstance(density, gemmi.Ccp4Map)

--- a/test/unit/test_testing.py
+++ b/test/unit/test_testing.py
@@ -22,17 +22,17 @@ def test_phases_allclose() -> None:
         mt.assert_phases_allclose(close1, far)
 
 
-def test_diffmap_realspace_rms(noise_free_map: Map) -> None:
-    assert mt.diffmap_realspace_rms(noise_free_map, noise_free_map) == 0.0
+def test_map_corrcoeff(noise_free_map: Map, np_rng: np.random.Generator) -> None:
+    assert mt.map_corrcoeff(noise_free_map, noise_free_map) == 1.0
 
-    map2 = noise_free_map.copy()
-    map2 += 1
-    map3 = noise_free_map.copy()
-    map3 += 2
+    noisy_map = noise_free_map.copy()
+    noise_free_map.amplitudes += np_rng.normal(size=len(noise_free_map))
+    noisier_map = noise_free_map.copy()
+    noise_free_map.amplitudes += np_rng.normal(size=len(noise_free_map))
 
-    dist12 = mt.diffmap_realspace_rms(noise_free_map, map2)
-    dist13 = mt.diffmap_realspace_rms(noise_free_map, map3)
-    assert dist13 > dist12
+    dist12 = mt.map_corrcoeff(noise_free_map, noisy_map)
+    dist13 = mt.map_corrcoeff(noise_free_map, noisier_map)
+    assert 1.0 > dist13 > dist12 > 0.0
 
 
 def test_single_carbon_structure_smoke() -> None:

--- a/test/unit/test_testing.py
+++ b/test/unit/test_testing.py
@@ -26,13 +26,13 @@ def test_map_corrcoeff(noise_free_map: Map, np_rng: np.random.Generator) -> None
     assert mt.map_corrcoeff(noise_free_map, noise_free_map) == 1.0
 
     noisy_map = noise_free_map.copy()
-    noise_free_map.amplitudes += np_rng.normal(size=len(noise_free_map))
+    noisy_map.amplitudes += np_rng.normal(size=len(noise_free_map))
     noisier_map = noise_free_map.copy()
-    noise_free_map.amplitudes += np_rng.normal(size=len(noise_free_map))
+    noisier_map.amplitudes += 10.0 * np_rng.normal(size=len(noise_free_map))
 
-    dist12 = mt.map_corrcoeff(noise_free_map, noisy_map)
-    dist13 = mt.map_corrcoeff(noise_free_map, noisier_map)
-    assert 1.0 > dist13 > dist12 > 0.0
+    noisy_cc = mt.map_corrcoeff(noise_free_map, noisy_map)
+    noisier_cc = mt.map_corrcoeff(noise_free_map, noisier_map)
+    assert 1.0 > noisy_cc > noisier_cc > 0.0
 
 
 def test_single_carbon_structure_smoke() -> None:

--- a/test/unit/test_tv.py
+++ b/test/unit/test_tv.py
@@ -10,7 +10,7 @@ import pytest
 
 from meteor import tv
 from meteor.rsmap import Map
-from meteor.testing import diffmap_realspace_rms
+from meteor.testing import map_corrcoeff
 from meteor.validate import map_negentropy
 
 DEFAULT_WEIGHTS_TO_SCAN = np.logspace(-2, 0, 25)
@@ -87,13 +87,13 @@ def test_tv_denoise_map(
     noise_free_map: Map,
     noisy_map: Map,
 ) -> None:
-    def rms_to_noise_free(test_map: Map) -> float:
-        return diffmap_realspace_rms(test_map, noise_free_map)
+    def cc_to_noise_free(test_map: Map) -> float:
+        return map_corrcoeff(test_map, noise_free_map)
 
     # Normally, the `tv_denoise_difference_map` function only returns the best result -- since we
     # know the ground truth, work around this to test all possible results.
 
-    lowest_rms: float = np.inf
+    best_cc: float = 0.0
     best_weight: float = 0.0
 
     for trial_weight in DEFAULT_WEIGHTS_TO_SCAN:
@@ -104,9 +104,9 @@ def test_tv_denoise_map(
             ],
             full_output=True,
         )
-        rms = rms_to_noise_free(denoised_map)
-        if rms < lowest_rms:
-            lowest_rms = rms
+        cc = cc_to_noise_free(denoised_map)
+        if cc > best_cc:
+            best_cc = cc
             best_weight = trial_weight
 
     # now run the denoising algorithm and make sure we get a result that's close
@@ -117,7 +117,7 @@ def test_tv_denoise_map(
         full_output=True,
     )
 
-    assert rms_to_noise_free(denoised_map) < rms_to_noise_free(noisy_map), "error didnt drop"
+    assert cc_to_noise_free(denoised_map) > cc_to_noise_free(noisy_map)
     np.testing.assert_allclose(
         result.optimal_tv_weight, best_weight, rtol=0.5, err_msg="opt weight"
     )


### PR DESCRIPTION
Some unit tests targeting the TV denoising code were broken or flakey. 

The idea behind these tests is to take a simple "ground truth" map, add some Gaussian noise, and then run TV denoising. Ideally, the output should be closer to the noise-free "ground truth" than the input.

But these tests were not faithfully reporting this because the map comparison was done by computing a normalized RMS between the two maps. The Pearson correlation, computed in real space, appears to provide a more robust signal, and this PR implements this change.

During the implementation, I realized that I was confused by the `rsmap.Map` methods. There is a `.to_numpy()` method inherited from `pandas` that provides the `F`, `PHI`, `SIGF` columns as numpy arrays. Useful, but for a moment, I thought I was getting real space maps. Therefore, this PR additionally implements a handy function that computes a `3d_numpy_map`, which hopefully will make this easier and clearer going forward.