### PR TITLE
pin to gemmi 0.6.6

### DIFF
--- a/meteor/testing.py
+++ b/meteor/testing.py
@@ -47,7 +47,7 @@ def single_carbon_structure(
     space_group: gemmi.SpaceGroup,
     unit_cell: gemmi.UnitCell,
 ) -> gemmi.Structure:
-    model = gemmi.Model(0)
+    model = gemmi.Model("model0")
     chain = gemmi.Chain("A")
 
     residue = gemmi.Residue()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
     "numpy >= 1.26",
     "scipy >= 1.14.0",
-    "gemmi >= 0.7.1",
+    "gemmi == 0.6.6",
     "scikit-image >= 0.24.0",
     "reciprocalspaceship >= 1.0.2",
     "structlog >= 24.4.0",


### PR DESCRIPTION
Right now we are waiting on a resolution to:
https://github.com/project-gemmi/gemmi/issues/366

I am not sure how to get by that without turning off `mypy`.

Will continue to experiment, but want to ensure we have a working version live.