### PR TITLE
scaling bug -- NaNs

### DIFF
--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -206,16 +206,21 @@ def scale_maps(
             reference_values=reference_map.amplitudes, values_to_scale=map_to_scale.amplitudes
         )
 
-    scaled_map: Map = map_to_scale.copy()
-    scaled_map = scaled_map[~np.isnan(scaled_map.amplitudes)]
-    if len(scaled_map) != len(scale_factors):
-        msg = f"map (len: {scaled_map}) and scale_factors (len: {scale_factors}) do not have a "
-        msg += "common size -- something went wrong, contact the developers"
+    number_of_non_nan_values_to_scale = np.sum(np.isfinite(map_to_scale.amplitudes))
+    if number_of_non_nan_values_to_scale != len(scale_factors):
+        msg = f"map (number of non-nan values: {number_of_non_nan_values_to_scale}) and  "
+        msg += f"scale_factors (len: {scale_factors}) do not have a common size -- something went "
+        msg += "wrong, contact the developers"
         raise RuntimeError(msg)
 
-    scaled_map.amplitudes *= scale_factors
+    scaled_map: Map = map_to_scale.copy()
+    scaled_map.loc[np.isfinite(scaled_map.amplitudes), scaled_map.amplitude_column_name] *= (
+        scale_factors
+    )
 
     if scaled_map.has_uncertainties:
-        scaled_map.uncertainties *= scale_factors
+        scaled_map.loc[
+            np.isfinite(scaled_map.amplitudes), scaled_map.uncertainties_column_name
+        ] *= scale_factors
 
     return scaled_map

--- a/meteor/scripts/common.py
+++ b/meteor/scripts/common.py
@@ -332,7 +332,7 @@ def kweight_diffmap_according_to_mode(
             mapset.derivative, mapset.native
         )
         log.info("  using negentropy max.", kparameter=kparameter_metadata.optimal_parameter_value)
-        if kweight_parameter is np.nan:
+        if np.isnan(kparameter_metadata.optimal_parameter_value):
             msg = "determined `k-parameter` is NaN, something went wrong..."
             raise RuntimeError(msg)
 

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -111,6 +111,18 @@ def test_scale_maps(random_difference_map: Map, use_uncertainties: bool) -> None
     )
 
 
+@pytest.mark.parametrize("use_uncertainties", [False, True])
+def test_scale_maps_nans_in_input(random_difference_map: Map, use_uncertainties: bool) -> None:
+    another_difference_map = random_difference_map.copy()
+    another_difference_map.loc[0, another_difference_map.amplitude_column_name] = np.nan
+
+    scale.scale_maps(
+        reference_map=random_difference_map,
+        map_to_scale=another_difference_map,
+        weight_using_uncertainties=use_uncertainties,
+    )
+
+
 def test_scale_maps_uncertainty_weighting() -> None:
     x = np.array([1, 2, 3])
     y = np.array([4, 8, 2])


### PR DESCRIPTION
@cvazz noticed that [scale_maps](https://github.com/rs-station/meteor/blob/5ecf9b8f55bd2022231b8454e2835017eff94501/meteor/scale.py#L143) has an issue with certain input, and is throwing a length mismatch error that is rather mysterious.

A quick look revealed that this is due to NaNs. In the upstream function [compute_scale_factors](https://github.com/rs-station/meteor/blob/5ecf9b8f55bd2022231b8454e2835017eff94501/meteor/scale.py#L44) we drop NaNs, but in `scale_maps` we don't. That creates the possibility for a shape mismatch.

I've implemented a basic fix. To do:
- [x] review this code and improve it
- [x] regression test