### PR TITLE
Scale for NaN values (Size Mismatch reference/to-be-scaled: fixed

### DIFF
--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -89,7 +89,9 @@ def compute_scale_factors(
     """
     reference_values.dropna(axis="index", how="any", inplace=True)
     # keep all indices to ensure we scale all values
-    v2s_all_indices = values_to_scale.index.copy()
+    index_locations = np.isfinite(values_to_scale)
+    all_finite_indices = values_to_scale[index_locations].index.copy()
+
     values_to_scale.dropna(axis="index", how="any", inplace=True)
 
     common_miller_indices: pd.Index = reference_values.index.intersection(values_to_scale.index)
@@ -130,13 +132,12 @@ def compute_scale_factors(
 
     # now be sure to compute the scale factors for all miller indices in `values_to_scale`
     optimized_scale_factors = _compute_anisotropic_scale_factors(
-        v2s_all_indices,
+        all_finite_indices,
         optimized_parameters,
     )
-    print("hi", len(optimized_scale_factors)
-    if len(optimized_scale_factors) != len(v2s_all_indices):
+    if len(optimized_scale_factors) != len(all_finite_indices):
         msg1 = "length mismatch: `optimized_scale_factors`"
-        msg2 = f"({len(optimized_scale_factors)}) vs `values_to_scale` ({len(v2s_all_indices)})"
+        msg2 = f"({len(optimized_scale_factors)}) vs `values_to_scale` ({len(all_finite_indices)})"
         raise RuntimeError(msg1, msg2)
 
     return optimized_scale_factors
@@ -211,7 +212,7 @@ def scale_maps(
     number_of_non_nan_values_to_scale = np.sum(np.isfinite(map_to_scale.amplitudes))
     if number_of_non_nan_values_to_scale != len(scale_factors):
         msg = f"map (number of non-nan values: {number_of_non_nan_values_to_scale}) and  "
-        msg += f"scale_factors (len: {scale_factors}) do not have a common size -- something went "
+        msg += f"scale_factors (len: {len(scale_factors)}) do not have a common size -- something went "
         msg += "wrong, contact the developers"
         raise RuntimeError(msg)
 

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -88,6 +88,8 @@ def compute_scale_factors(
     [1] SCALEIT https://www.ccp4.ac.uk/html/scaleit.html
     """
     reference_values.dropna(axis="index", how="any", inplace=True)
+    # keep all indices to ensure we scale all values
+    v2s_all_indices = values_to_scale.index.copy()
     values_to_scale.dropna(axis="index", how="any", inplace=True)
 
     common_miller_indices: pd.Index = reference_values.index.intersection(values_to_scale.index)
@@ -128,13 +130,13 @@ def compute_scale_factors(
 
     # now be sure to compute the scale factors for all miller indices in `values_to_scale`
     optimized_scale_factors = _compute_anisotropic_scale_factors(
-        values_to_scale.index,
+        v2s_all_indices,
         optimized_parameters,
     )
-
-    if len(optimized_scale_factors) != len(values_to_scale):
+    print("hi", len(optimized_scale_factors)
+    if len(optimized_scale_factors) != len(v2s_all_indices):
         msg1 = "length mismatch: `optimized_scale_factors`"
-        msg2 = f"({len(optimized_scale_factors)}) vs `values_to_scale` ({len(values_to_scale)})"
+        msg2 = f"({len(optimized_scale_factors)}) vs `values_to_scale` ({len(v2s_all_indices)})"
         raise RuntimeError(msg1, msg2)
 
     return optimized_scale_factors

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -206,16 +206,21 @@ def scale_maps(
             reference_values=reference_map.amplitudes, values_to_scale=map_to_scale.amplitudes
         )
 
-    scaled_map: Map = map_to_scale.copy()
-    scaled_map = scaled_map[~np.isnan(scaled_map.amplitudes)]
-    if len(scaled_map) != len(scale_factors):
-        msg = f"map (len: {scaled_map}) and scale_factors (len: {scale_factors}) do not have a "
-        msg += "common size -- something went wrong, contact the developers"
+    number_of_non_nan_values_to_scale = np.sum(np.isfinite(map_to_scale.amplitudes))
+    if number_of_non_nan_values_to_scale != len(scale_factors):
+        msg = f"map (number of non-nan values: {number_of_non_nan_values_to_scale}) and  "
+        msg += f"scale_factors (len: {scale_factors}) do not have a common size -- something went "
+        msg += "wrong, contact the developers"
         raise RuntimeError(msg)
 
-    scaled_map.amplitudes *= scale_factors
+    scaled_map: Map = map_to_scale.copy()
+    scaled_map.loc[np.isfinite(scaled_map.amplitudes), scaled_map.amplitude_column_name] *= (
+        scale_factors
+    )
 
     if scaled_map.has_uncertainties:
-        scaled_map.uncertainties *= scale_factors
+        scaled_map.loc[
+            np.isfinite(scaled_map.amplitudes), scaled_map.uncertainties_column_name
+        ] *= scale_factors
 
     return scaled_map

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -208,7 +208,7 @@ def scale_maps(
 
     scaled_map: Map = map_to_scale.copy()
     scaled_map = scaled_map[~np.isnan(scaled_map.amplitudes)]
-    if not len(scaled_map) == len(scale_factors):
+    if len(scaled_map) != len(scale_factors):
         msg = f"map (len: {scaled_map}) and scale_factors (len: {scale_factors}) do not have a "
         msg += "common size -- something went wrong, contact the developers"
         raise RuntimeError(msg)

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -207,7 +207,14 @@ def scale_maps(
         )
 
     scaled_map: Map = map_to_scale.copy()
+    scaled_map = scaled_map[~np.isnan(scaled_map.amplitudes)]
+    if not len(scaled_map) == len(scale_factors):
+        msg = f"map (len: {scaled_map}) and scale_factors (len: {scale_factors}) do not have a "
+        msg += "common size -- something went wrong, contact the developers"
+        raise RuntimeError(msg)
+
     scaled_map.amplitudes *= scale_factors
+
     if scaled_map.has_uncertainties:
         scaled_map.uncertainties *= scale_factors
 

--- a/meteor/scripts/common.py
+++ b/meteor/scripts/common.py
@@ -332,7 +332,7 @@ def kweight_diffmap_according_to_mode(
             mapset.derivative, mapset.native
         )
         log.info("  using negentropy max.", kparameter=kparameter_metadata.optimal_parameter_value)
-        if kweight_parameter is np.nan:
+        if np.isnan(kparameter_metadata.optimal_parameter_value):
             msg = "determined `k-parameter` is NaN, something went wrong..."
             raise RuntimeError(msg)
 

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -111,6 +111,18 @@ def test_scale_maps(random_difference_map: Map, use_uncertainties: bool) -> None
     )
 
 
+@pytest.mark.parametrize("use_uncertainties", [False, True])
+def test_scale_maps_nans_in_input(random_difference_map: Map, use_uncertainties: bool) -> None:
+    another_difference_map = random_difference_map.copy()
+    another_difference_map.loc[0, another_difference_map.amplitude_column_name] = np.nan
+
+    scale.scale_maps(
+        reference_map=random_difference_map,
+        map_to_scale=another_difference_map,
+        weight_using_uncertainties=use_uncertainties,
+    )
+
+
 def test_scale_maps_uncertainty_weighting() -> None:
     x = np.array([1, 2, 3])
     y = np.array([4, 8, 2])

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -57,6 +57,7 @@ def test_compute_scale_factors_nans(miller_dataseries: rs.DataSeries) -> None:
     with_nans = miller_dataseries.copy()
     with_nans.iloc[0] = np.nan
     miller_dataseries.iloc[1] = np.nan
+    miller_dataseries.iloc[2] = np.nan
     scale_factors = scale.compute_scale_factors(
         reference_values=miller_dataseries,
         values_to_scale=with_nans,


### PR DESCRIPTION
In the previous version, scaling was only possible if there was an equal number of NaN values in both the reference and the to be scaled map. 

This happened because NaN indices were dropped for both reference as well as to be scaled data. Later the scaling parameters are calculated based on the modified reference state indices, meaning a size Error was thrown.  

I addressed this by ensuring by filtering for all finite indices in the map to be scaled. Then I calculate all values at those indices in compute_scale_factors and ensure that they end up in the right place in the map to be scaled (in scale_factors).

Also I changed the test.