### PR TITLE
Feature: Add global scaling

### DIFF
--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -61,7 +61,7 @@ def compute_scale_factors(
 
     The parameters Bxy are fit using least squares, optionally with uncertainty weighting.
 
-    If `only_global_constant` is set to True, the function will compute a single global scale rather 
+    If `only_global_constant` is set to True, the function will compute a single global scale rather
     than the anisotropic model described above.
 
     Parameters
@@ -148,8 +148,8 @@ def compute_scale_factors(
         optimization_result = opt.least_squares(
             compute_constant, initial_scaling_parameter
         )
-        optimized_parameter = optimization_result.x
-        return optimized_parameter
+        return optimization_result.x[0]
+        
 
     initial_scaling_parameters: ScaleParameters = (1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     optimization_result = opt.least_squares(compute_residuals, initial_scaling_parameters)
@@ -192,7 +192,7 @@ def scale_maps(
     modified (scaled). To access the scale parameters directly, use
     `meteor.scale.compute_scale_factors`.
 
-    If `only_global_constant` is set to True, the function will compute a single global scale rather 
+    If `only_global_constant` is set to True, the function will compute a single global scale rather
     than the anisotropic model described above.
 
     Parameters
@@ -238,15 +238,14 @@ def scale_maps(
         )
     else:
         scale_factors = compute_scale_factors(
-            reference_values=reference_map.amplitudes, 
+            reference_values=reference_map.amplitudes,
             values_to_scale=map_to_scale.amplitudes,
             only_global_constant=only_global_constant,
         )
 
     number_of_non_nan_values_to_scale = np.sum(np.isfinite(map_to_scale.amplitudes))
-    if number_of_non_nan_values_to_scale != len(scale_factors):
+    if not only_global_constant and number_of_non_nan_values_to_scale != len(scale_factors):
         msg = f"map (number of non-nan values: {number_of_non_nan_values_to_scale}) and  "
-
         msg += f"scale_factors (len: {len(scale_factors)}) do not have a common size -- something went "
         msg += "wrong, contact the developers"
         raise RuntimeError(msg)

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -233,12 +233,13 @@ def scale_maps(
             ),
             to_scale_uncertainties=(
                 map_to_scale.uncertainties if map_to_scale.has_uncertainties else None
-            only_global_constant=only_global_constant,
             ),
+            only_global_constant=only_global_constant,
         )
     else:
         scale_factors = compute_scale_factors(
-            reference_values=reference_map.amplitudes, values_to_scale=map_to_scale.amplitudes
+            reference_values=reference_map.amplitudes, 
+            values_to_scale=map_to_scale.amplitudes,
             only_global_constant=only_global_constant,
         )
 

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -134,7 +134,7 @@ def compute_scale_factors(
 
         return residuals
 
-    def compute_constant(scale_factor: float):
+    def compute_constant(scale_factor: float) -> np.ndarray:
         difference_after_scaling = scale_factor * common_values_to_scale - common_reference_values
         residuals = inverse_variance * difference_after_scaling
 

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -76,11 +76,14 @@ def compute_scale_factors(
     to_scale_uncertainties : rs.DataSeries, optional
         Uncertainty values associated with `values_to_scale`. If provided, they are used in
         weighting the scaling process. Must have the same index as `values_to_scale`.
+    only_global_constant : bool, optional (default: False)
+        If True, compute a single global scale factor instead of an anisotropic model.
 
     Returns
     -------
-    rs.DataSeries
+    rs.DataSeries | float
         The computed anisotropic scale factors for each Miller index in `values_to_scale`.
+        If `only_global_constant` is True, a single global scale factor is returned instead.
 
     See Also
     --------
@@ -170,6 +173,7 @@ def scale_maps(
     reference_map: Map,
     map_to_scale: Map,
     weight_using_uncertainties: bool = True,
+    only_global_constant: bool = False,
 ) -> Map:
     """
     Scale a dataset to align it with a reference dataset using anisotropic scaling.
@@ -188,6 +192,9 @@ def scale_maps(
     modified (scaled). To access the scale parameters directly, use
     `meteor.scale.compute_scale_factors`.
 
+    If `only_global_constant` is set to True, the function will compute a single global scale rather 
+    than the anisotropic model described above.
+
     Parameters
     ----------
     reference_map : Map
@@ -197,6 +204,8 @@ def scale_maps(
     weight_using_uncertainties : bool, optional (default: True)
         Whether or not to weight the scaling by uncertainty values. If True, uncertainty values are
         extracted from the `uncertainty_column` in both datasets.
+    only_global_constant : bool, optional (default: False)
+        If True, compute a single global scale factor instead of an anisotropic model.
 
     Returns
     -------
@@ -224,11 +233,13 @@ def scale_maps(
             ),
             to_scale_uncertainties=(
                 map_to_scale.uncertainties if map_to_scale.has_uncertainties else None
+            only_global_constant=only_global_constant,
             ),
         )
     else:
         scale_factors = compute_scale_factors(
             reference_values=reference_map.amplitudes, values_to_scale=map_to_scale.amplitudes
+            only_global_constant=only_global_constant,
         )
 
     number_of_non_nan_values_to_scale = np.sum(np.isfinite(map_to_scale.amplitudes))

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -87,7 +87,7 @@ def compute_scale_factors(
 
     See Also
     --------
-    scale_datasets : higher-level interface that operates on entire DataSets, typically more
+    scale_maps : higher-level interface that operates on entire DataSets, typically more
     convienent.
 
     Citations:


### PR DESCRIPTION
An attempt at making a simple global scaling factor calculation available besides the anisotropic scaling that was available already. 

Note that the return type of `compute_scale_factors` can change to float. 

Is there anything else that should be added?