### PR TITLE
tv_weight_optmization-> typo in metadata variable

### DIFF
--- a/meteor/metadata.py
+++ b/meteor/metadata.py
@@ -27,7 +27,7 @@ class TvScanMetadata(MaximizerScanMetadata):
 
 class DiffmapMetadata(BaseModel):
     k_parameter_optimization: KparameterScanMetadata | None
-    tv_weight_optmization: TvScanMetadata
+    tv_weight_optimization: TvScanMetadata
 
 
 class TvIterationMetadata(BaseModel):

--- a/meteor/scripts/diffmap.py
+++ b/meteor/scripts/diffmap.py
@@ -157,13 +157,13 @@ def compute_meteor_difference_map(
         tv_denoise_mode=tv_denoise_mode, tv_weight=tv_weight, diffmap=diffmap
     )
     aggregate_metadata = DiffmapMetadata(
-        k_parameter_optimization=kparameter_metadata, tv_weight_optmization=tv_metadata
+        k_parameter_optimization=kparameter_metadata, tv_weight_optimization=tv_metadata
     )
 
-    if aggregate_metadata.tv_weight_optmization.optimal_negentropy <= 0.0:
+    if aggregate_metadata.tv_weight_optimization.optimal_negentropy <= 0.0:
         log.warning(
             NEGATIVE_NEGENTROPY_WARNING_MESSAGE,
-            final_negentropy=aggregate_metadata.tv_weight_optmization.optimal_negentropy,
+            final_negentropy=aggregate_metadata.tv_weight_optimization.optimal_negentropy,
         )
 
     return final_map, aggregate_metadata

--- a/test/functional/test_diffmap.py
+++ b/test/functional/test_diffmap.py
@@ -69,13 +69,13 @@ def test_script_produces_consistent_results(
     # 1. make sure negentropy increased
     if tv_weight_mode == WeightMode.none:
         np.testing.assert_allclose(
-            diffmap_metadata.tv_weight_optmization.optimal_negentropy,
-            diffmap_metadata.tv_weight_optmization.initial_negentropy,
+            diffmap_metadata.tv_weight_optimization.optimal_negentropy,
+            diffmap_metadata.tv_weight_optimization.initial_negentropy,
         )
     else:
         assert (
-            diffmap_metadata.tv_weight_optmization.optimal_negentropy
-            >= diffmap_metadata.tv_weight_optmization.initial_negentropy
+            diffmap_metadata.tv_weight_optimization.optimal_negentropy
+            >= diffmap_metadata.tv_weight_optimization.initial_negentropy
         )
 
     # 2. make sure optimized weights close to expected
@@ -92,7 +92,7 @@ def test_script_produces_consistent_results(
             optimal_tv_no_kweighting = 0.025
             np.testing.assert_allclose(
                 optimal_tv_no_kweighting,
-                diffmap_metadata.tv_weight_optmization.optimal_parameter_value,
+                diffmap_metadata.tv_weight_optimization.optimal_parameter_value,
                 rtol=0.1,
                 err_msg="tv weight optimium different from expected",
             )
@@ -100,7 +100,7 @@ def test_script_produces_consistent_results(
             optimal_tv_with_weighting = 0.00867
             np.testing.assert_allclose(
                 optimal_tv_with_weighting,
-                diffmap_metadata.tv_weight_optmization.optimal_parameter_value,
+                diffmap_metadata.tv_weight_optimization.optimal_parameter_value,
                 rtol=0.1,
                 err_msg="tv weight optimium different from expected",
             )


### PR DESCRIPTION
I noticed this typo in DiffmapMetadata.tv_weight_optmization (the first I is missing in optimization) and it was bugging me (:

So here is a teeny tiny pull request.
