### PR TITLE
add scaling to notebook example

### DIFF
--- a/examples/customized_meteor_diffmap.ipynb
+++ b/examples/customized_meteor_diffmap.ipynb
@@ -23,9 +23,9 @@
     "\n",
     "from meteor.diffmaps import compute_difference_map, max_negentropy_kweighted_difference_map\n",
     "from meteor.rsmap import Map\n",
+    "from meteor.scale import scale_maps\n",
     "from meteor.tv import tv_denoise_difference_map\n",
-    "from meteor.validate import map_negentropy\n",
-    "from meteor.scale import scale_maps"
+    "from meteor.validate import map_negentropy"
    ]
   },
   {


### PR DESCRIPTION
This PR addresses issue #111 by adding a single function call to `customized_meteor_diffmap.ipynb`, which scales the two maps together.

The result is satisfactory:

<img width="739" height="710" alt="Screenshot 2025-12-28 at 10 08 15 PM" src="https://github.com/user-attachments/assets/bef9d6b2-924b-451f-85fa-7e2e26e627a1" />

Interestingly, in the example notebook I observed that cutting the resolution to 1.6 Å causes the k-weighting scheme to completely mess up the resulting diffmap. If you either leave the data at ~1.4 Å and keep the k-weighting, OR cut at 1.6 Å and omit k-weighting, you get a reasonable result.

Fortunately the negentropy reports this all faithfully.

We should aim to abolish k-weighting ASAP, but that's another fight.