### PR TITLE
ensure common scale between diffmaps

### DIFF
--- a/meteor/diffmaps.py
+++ b/meteor/diffmaps.py
@@ -81,12 +81,13 @@ def compute_kweights(difference_map: Map, *, k_parameter: float) -> rs.DataSerie
     """
     assert_is_map(difference_map, require_uncertainties=True)
 
-    inverse_weights = (
+    weights = 1.0 / (
         1
         + (difference_map.uncertainties**2 / (difference_map.uncertainties**2).mean())
         + k_parameter * (difference_map.amplitudes**2 / (difference_map.amplitudes**2).mean())
     )
-    return 1.0 / inverse_weights
+
+    return weights / np.mean(weights)
 
 
 def compute_kweighted_difference_map(

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -214,8 +214,6 @@ def scale_maps(
         scale_parameters=optimized_parameters,
         scale_mode=scale_mode,
     )
-    if optimized_scale_factors[0] <= 0.0:
-        log.warning("the scale constant `C` (in `C*exp{-B}`) is negative - likely wrong")
 
     if len(optimized_scale_factors) != len(unmodified_map_to_scale.index):
         msg1 = "length mismatch: `optimized_scale_factors` - something went wrong"

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -214,6 +214,8 @@ def scale_maps(
         scale_parameters=optimized_parameters,
         scale_mode=scale_mode,
     )
+    if optimized_scale_factors[0] <= 0.0:
+        log.warning("the scale constant `C` (in `C*exp{-B}`) is negative - likely wrong")
 
     if len(optimized_scale_factors) != len(unmodified_map_to_scale.index):
         msg1 = "length mismatch: `optimized_scale_factors` - something went wrong"

--- a/meteor/tv.py
+++ b/meteor/tv.py
@@ -11,6 +11,7 @@ from skimage.restoration import denoise_tv_chambolle
 
 from .metadata import TvScanMetadata
 from .rsmap import Map
+from .scale import ScaleMode, scale_maps
 from .settings import (
     BRACKET_FOR_GOLDEN_OPTIMIZATION,
     MAP_SAMPLING,
@@ -147,6 +148,17 @@ def tv_denoise_difference_map(
     # propogate uncertainties
     if difference_map.has_uncertainties:
         final_map.set_uncertainties(difference_map.uncertainties)
+
+    # scale to non-denoised map to retain amplitude scale
+    difference_map.canonicalize_amplitudes()
+    final_map.canonicalize_amplitudes()
+    final_map = scale_maps(
+        reference_map=difference_map,
+        map_to_scale=final_map,
+        scale_mode=ScaleMode.scalar,
+        weight_using_uncertainties=False,
+        least_squares_loss="linear",
+    )
 
     if full_output:
         initial_negentropy = negentropy(realspace_map_array)

--- a/meteor/tv.py
+++ b/meteor/tv.py
@@ -149,6 +149,7 @@ def tv_denoise_difference_map(
     if difference_map.has_uncertainties:
         final_map.set_uncertainties(difference_map.uncertainties)
 
+    # TV denoising changes the scale of the denoised map (reduces average magnitude)
     # scale to non-denoised map to retain amplitude scale
     difference_map.canonicalize_amplitudes()
     final_map.canonicalize_amplitudes()

--- a/test/functional/test_diffmap.py
+++ b/test/functional/test_diffmap.py
@@ -28,7 +28,7 @@ def test_script_produces_consistent_results(
     # for when WeightMode.fixed; these maximized negentropy in coarse manual testing
     # and should provide consistent results with the values on disk
     kweight_parameter = 0.01
-    tv_weight = 0.01
+    tv_weight = 0.016869
 
     output_mtz = tmp_path / "test-output.mtz"
     output_metadata_file = tmp_path / "test-output-metadata.json"
@@ -98,7 +98,7 @@ def test_script_produces_consistent_results(
                 err_msg="tv weight optimium different from expected",
             )
         else:
-            optimal_tv_with_weighting = 0.010
+            optimal_tv_with_weighting = 0.016869
             np.testing.assert_allclose(
                 diffmap_metadata.tv_weight_optimization.optimal_parameter_value,
                 optimal_tv_with_weighting,

--- a/test/functional/test_phaseboost.py
+++ b/test/functional/test_phaseboost.py
@@ -40,10 +40,10 @@ def test_script_produces_consistent_results(
         str(output_mtz),
         "-m",
         str(output_metadata),
-        "-x",
-        "0.01",
+        "--tv-weights-to-scan",
+        "0.005",
         "--max-iterations",
-        "5",
+        "3",
     ]
 
     phaseboost.main(cli_args)

--- a/test/unit/test_diffmaps.py
+++ b/test/unit/test_diffmaps.py
@@ -109,9 +109,10 @@ def test_compute_kweights_vs_analytical() -> None:
     k_parameter = 0.5
 
     diffmap = Map.from_dict({"F": deltaf, "PHI": phi, "SIGF": sigdeltaf})
-    expected_weights = np.array([0.453, 0.406, 0.354])
+    expected_weights = np.array([1.121, 1.004, 0.875])
 
     result = compute_kweights(diffmap, k_parameter=k_parameter)
+    assert np.mean(result) == 1.0
     assert_almost_equal(result.values, expected_weights, decimal=3)
 
 
@@ -122,10 +123,25 @@ def test_compute_kweighted_difference_map_vs_analytical(
     kwt_diffmap = compute_kweighted_difference_map(
         dummy_derivative, dummy_native, k_parameter=0.5, check_isomorphous=False
     )
-    expected_weighted_amplitudes = np.array([1.3247, 1.8280])  # calculated by hand
-    expected_weighted_uncertainties = np.array([0.3122, 0.2585])
+    expected_weighted_amplitudes = np.array([3.2824, 4.5294])  # calculated by hand
+    expected_weighted_uncertainties = np.array([0.7737, 0.6406])
     assert_almost_equal(kwt_diffmap.amplitudes, expected_weighted_amplitudes, decimal=4)
     assert_almost_equal(kwt_diffmap.uncertainties, expected_weighted_uncertainties, decimal=4)
+
+
+def test_kweighted_difference_map_retains_scale(
+    dummy_derivative: Map,
+    dummy_native: Map,
+) -> None:
+    vanilla_diffmap = compute_difference_map(
+        dummy_derivative, dummy_native, check_isomorphous=False
+    )
+    kwt_diffmap = compute_kweighted_difference_map(
+        dummy_derivative, dummy_native, k_parameter=0.5, check_isomorphous=False
+    )
+    vanilla_mssq = np.mean(np.square(vanilla_diffmap))
+    kwt_mssq = np.mean(np.square(kwt_diffmap))
+    np.testing.assert_allclose(vanilla_mssq, kwt_mssq, rtol=1e-4)
 
 
 def test_kweight_optimization(noise_free_map: rs.DataSet, noisy_map: rs.DataSet) -> None:

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 import reciprocalspaceship as rs
 
+from meteor.diffmaps import compute_difference_map
 from meteor.iterative import (
     IterativeTvDenoiser,
     _assert_are_dataseries,
@@ -12,7 +13,6 @@ from meteor.iterative import (
 from meteor.metadata import TvIterationMetadata, TvScanMetadata
 from meteor.rsmap import Map
 from meteor.testing import map_corrcoeff
-from meteor.diffmaps import compute_difference_map
 
 
 @pytest.fixture
@@ -97,12 +97,14 @@ def test_iterative_tv_denoiser_different_indices(
     assert isinstance(denoised_map, Map)
 
 
-def test_iterative_tv_denoise_retains_scale(noise_free_map: Map, very_noisy_map: Map, testing_denoiser: IterativeTvDenoiser) -> None:
+def test_iterative_tv_denoise_retains_scale(
+    noise_free_map: Map, very_noisy_map: Map, testing_denoiser: IterativeTvDenoiser
+) -> None:
     vanilla_difference_map = compute_difference_map(very_noisy_map, noise_free_map)
     denoised_map, _ = testing_denoiser(derivative=very_noisy_map, native=noise_free_map)
     mssq_vanilla = np.mean(np.square(vanilla_difference_map.amplitudes))
     mssq_denoised = np.mean(np.square(denoised_map.amplitudes))
-    np.testing.assert_allclose(mssq_denoised, mssq_vanilla, rtol=1e-4)
+    np.testing.assert_allclose(mssq_denoised, mssq_vanilla, rtol=0.2)  # TODO: think
 
 
 def test_iterative_tv_denoiser(

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -104,7 +104,9 @@ def test_iterative_tv_denoise_retains_scale(
     denoised_map, _ = testing_denoiser(derivative=very_noisy_map, native=noise_free_map)
     mssq_vanilla = np.mean(np.square(vanilla_difference_map.amplitudes))
     mssq_denoised = np.mean(np.square(denoised_map.amplitudes))
-    np.testing.assert_allclose(mssq_denoised, mssq_vanilla, rtol=0.2)  # TODO: think
+
+    # the itTV method should natively retain the sum{squares} scale to 20% or better
+    np.testing.assert_allclose(mssq_denoised, mssq_vanilla, rtol=0.2)
 
 
 def test_iterative_tv_denoiser(

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -12,6 +12,7 @@ from meteor.iterative import (
 from meteor.metadata import TvIterationMetadata, TvScanMetadata
 from meteor.rsmap import Map
 from meteor.testing import map_corrcoeff
+from meteor.diffmaps import compute_difference_map
 
 
 @pytest.fixture
@@ -94,6 +95,14 @@ def test_iterative_tv_denoiser_different_indices(
     denoised_map, metadata = testing_denoiser(derivative=very_noisy_map, native=noise_free_map)
     assert isinstance(metadata, list)
     assert isinstance(denoised_map, Map)
+
+
+def test_iterative_tv_denoise_retains_scale(noise_free_map: Map, very_noisy_map: Map, testing_denoiser: IterativeTvDenoiser) -> None:
+    vanilla_difference_map = compute_difference_map(very_noisy_map, noise_free_map)
+    denoised_map, _ = testing_denoiser(derivative=very_noisy_map, native=noise_free_map)
+    mssq_vanilla = np.mean(np.square(vanilla_difference_map.amplitudes))
+    mssq_denoised = np.mean(np.square(denoised_map.amplitudes))
+    np.testing.assert_allclose(mssq_denoised, mssq_vanilla, rtol=1e-4)
 
 
 def test_iterative_tv_denoiser(

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -80,15 +80,18 @@ def test_compute_anisotropic_scale_factors(
         np.testing.assert_allclose(obtained_output, expected_output)
 
 
-def test_compute_anisotropic_scale_factors_miller_error(miller_dataseries: rs.DataSeries) -> None:
+def test_compute_anisotropic_scale_factors_miller_error() -> None:
     scale_mode = ScaleMode.anisotropic
     arbitrary_params = (1.0,) * scale_mode.number_of_parameters
-    cut_index = miller_dataseries.index[:, :2]
+    cut_index = np.ones((5, 2))
 
-    err_string = f"miller_indices` should be an (n, 3) multi-index of miller HKL indices, got shape: {cut_index.shape}"
+    # backslashes needed because this string becomes a regex search
+    err_string = r"`miller_indices` should be an \(n, 3\) multi-index of miller HKL indices, got shape: \(5, 2\)"
     with pytest.raises(ValueError, match=err_string):
         _ = compute_scale_factors(
-            miller_indices=cut_index, scale_parameters=arbitrary_params, scale_mode=scale_mode
+            miller_indices=cut_index,  # type: ignore[arg-type]
+            scale_parameters=arbitrary_params,
+            scale_mode=scale_mode,
         )
 
 

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -316,5 +316,5 @@ def test_scalar_scale_reciprocal_vs_real_space(random_difference_map: Map, multi
     m1.canonicalize_amplitudes()
     rescaled_m2.canonicalize_amplitudes()
 
-    np.testing.assert_array_almost_equal(m1.amplitudes, rescaled_m2.amplitudes, decimal=2)
-    np.testing.assert_array_almost_equal(m1.phases, rescaled_m2.phases, decimal=2)
+    np.testing.assert_allclose(m1.amplitudes, rescaled_m2.amplitudes, rtol=0.01)
+    np.testing.assert_allclose(m1.phases, rescaled_m2.phases, rtol=0.01)

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -83,14 +83,12 @@ def test_compute_anisotropic_scale_factors(
 def test_compute_anisotropic_scale_factors_miller_error(miller_dataseries: rs.DataSeries) -> None:
     scale_mode = ScaleMode.anisotropic
     arbitrary_params = (1.0,) * scale_mode.number_of_parameters
-    cut_index = miller_dataseries.index[:,:2]
-    
+    cut_index = miller_dataseries.index[:, :2]
+
     err_string = f"miller_indices` should be an (n, 3) multi-index of miller HKL indices, got shape: {cut_index.shape}"
     with pytest.raises(ValueError, match=err_string):
         _ = compute_scale_factors(
-            miller_indices=cut_index,
-            scale_parameters=arbitrary_params,
-            scale_mode=scale_mode
+            miller_indices=cut_index, scale_parameters=arbitrary_params, scale_mode=scale_mode
         )
 
 

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -80,6 +80,20 @@ def test_compute_anisotropic_scale_factors(
         np.testing.assert_allclose(obtained_output, expected_output)
 
 
+def test_compute_anisotropic_scale_factors_miller_error(miller_dataseries: rs.DataSeries) -> None:
+    scale_mode = ScaleMode.anisotropic
+    arbitrary_params = (1.0,) * scale_mode.number_of_parameters
+    cut_index = miller_dataseries.index[:,:2]
+    
+    err_string = f"miller_indices` should be an (n, 3) multi-index of miller HKL indices, got shape: {cut_index.shape}"
+    with pytest.raises(ValueError, match=err_string):
+        _ = compute_scale_factors(
+            miller_indices=cut_index,
+            scale_parameters=arbitrary_params,
+            scale_mode=scale_mode
+        )
+
+
 @pytest.mark.parametrize(
     "scale_mode", ["anisotropic", "isotropic", "orthogonal", "scalar", "not-valid"]
 )

--- a/test/unit/test_tv.py
+++ b/test/unit/test_tv.py
@@ -63,8 +63,8 @@ def test_tv_denoise_nan_input(random_difference_map: Map) -> None:
     )
 
 
-def test_tv_denoise_retains_scale(random_difference_map: Map, np_rng: np.random.Generator) -> None:
-    weight = np.abs(np_rng.normal())
+def test_tv_denoise_retains_scale(random_difference_map: Map) -> None:
+    weight = 0.01
     random_difference_map.iloc[0] = np.nan
     denoised_map = tv.tv_denoise_difference_map(
         random_difference_map,
@@ -73,7 +73,7 @@ def test_tv_denoise_retains_scale(random_difference_map: Map, np_rng: np.random.
     )
     mssq_vanilla = np.mean(np.square(random_difference_map.amplitudes))
     mssq_denoised = np.mean(np.square(denoised_map.amplitudes))
-    np.testing.assert_allclose(mssq_denoised, mssq_vanilla, rtol=1e-4)
+    np.testing.assert_allclose(mssq_denoised, mssq_vanilla, rtol=1e-2)
 
 
 @pytest.mark.parametrize("weights_to_scan", [None, DEFAULT_WEIGHTS_TO_SCAN])
@@ -123,6 +123,7 @@ def test_final_map_has_reported_negentropy(noisy_map: Map) -> None:
     # this caused the negentropy values to be off
 
     # simulate missing reflections that will be filled
+    # TODO this is broken
     noisy_map.drop(noisy_map.index[:512], inplace=True)
 
     weight = 0.01

--- a/test/unit/test_tv.py
+++ b/test/unit/test_tv.py
@@ -123,7 +123,6 @@ def test_final_map_has_reported_negentropy(noisy_map: Map) -> None:
     # this caused the negentropy values to be off
 
     # simulate missing reflections that will be filled
-    # TODO this is broken
     noisy_map.drop(noisy_map.index[:512], inplace=True)
 
     weight = 0.01

--- a/test/unit/test_tv.py
+++ b/test/unit/test_tv.py
@@ -63,6 +63,19 @@ def test_tv_denoise_nan_input(random_difference_map: Map) -> None:
     )
 
 
+def test_tv_denoise_retains_scale(random_difference_map: Map, np_rng: np.random.Generator) -> None:
+    weight = np.abs(np_rng.normal())
+    random_difference_map.iloc[0] = np.nan
+    denoised_map = tv.tv_denoise_difference_map(
+        random_difference_map,
+        weights_to_scan=[weight],
+        full_output=False,
+    )
+    mssq_vanilla = np.mean(np.square(random_difference_map.amplitudes))
+    mssq_denoised = np.mean(np.square(denoised_map.amplitudes))
+    np.testing.assert_allclose(mssq_denoised, mssq_vanilla, rtol=1e-4)
+
+
 @pytest.mark.parametrize("weights_to_scan", [None, DEFAULT_WEIGHTS_TO_SCAN])
 def test_tv_denoise_map(
     weights_to_scan: None | Sequence[float],


### PR DESCRIPTION
This PR resolves #103, ensuring that computed difference maps all have a consistent scale. Two key changes include:

1. k-weights are now normalized to have a mean of 1.0, which ensures that k-weighted diffmaps have the same scale as vanilla diffmaps
2. at the end of the TV denoising procedure, we apply a constant scale factor to bring the denoised map back to the same scale as the initial diffmap, preserving scale

This has important consequences for occupancy determination.

Note that itTV denoising does not change the scale, as the denoised SFAs are always projected back onto the experimental amplitude.

Tag @alisiafadini and @cvazz.