### PR TITLE
scaling function guardrails

### DIFF
--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -184,6 +184,9 @@ def scale_maps(
             scale_parameters=scale_parameters,
             scale_mode=scale_mode,
         )
+        if not np.all(np.isfinite(scale_factors)):
+            msg = "scaling procedure failed -- optimization produced non finite values"
+            raise RuntimeError(msg)
 
         difference_after_scaling = (
             scale_factors * map_to_scale.amplitudes - reference_map.amplitudes
@@ -199,7 +202,8 @@ def scale_maps(
 
         return residuals
 
-    initial_scaling_parameters: ScaleParameters = (1.0,) + (0.0,) * (
+    initial_constant_scale_factor = np.mean(map_to_scale.amplitudes / reference_map.amplitudes)
+    initial_scaling_parameters: ScaleParameters = (initial_constant_scale_factor,) + (0.0,) * (
         scale_mode.number_of_parameters - 1
     )
     optimization_result = opt.least_squares(

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -185,7 +185,9 @@ def scale_maps(
             scale_mode=scale_mode,
         )
         if not np.all(np.isfinite(scale_factors)):
-            msg = "scaling procedure failed -- optimization produced non finite values"
+            msg = "Scaling procedure failed -- optimization produced non finite values. "
+            msg += "This can be caused by unusual input values. "
+            msg += "Recommend: check the input data for severe outliers."
             raise RuntimeError(msg)
 
         difference_after_scaling = (
@@ -202,8 +204,7 @@ def scale_maps(
 
         return residuals
 
-    initial_constant_scale_factor = np.mean(map_to_scale.amplitudes / reference_map.amplitudes)
-    initial_scaling_parameters: ScaleParameters = (initial_constant_scale_factor,) + (0.0,) * (
+    initial_scaling_parameters: ScaleParameters = (1.0,) + (0.0,) * (
         scale_mode.number_of_parameters - 1
     )
     optimization_result = opt.least_squares(

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -264,3 +265,19 @@ def test_scale_mismatched_indices(
         scale_mode=scale_mode,
         least_squares_loss=least_squares_loss,
     )
+
+
+def test_scale_maps_raises_on_non_finite_scale_factors(random_difference_map: Map) -> None:
+    with patch("meteor.scale.compute_scale_factors") as mock_compute_scale_factors:
+        mock_scale_factors = np.ones(len(random_difference_map))
+        mock_scale_factors[0] = np.inf  # Insert a non-finite value
+        mock_compute_scale_factors.return_value = mock_scale_factors
+
+        with pytest.raises(
+            RuntimeError,
+            match="Scaling procedure failed -- optimization produced non finite values",
+        ):
+            scale.scale_maps(
+                reference_map=random_difference_map,
+                map_to_scale=random_difference_map,
+            )


### PR DESCRIPTION
If crazy data are passed to the scaling function, it can produce `np.inf`s and crash mysteriously. This PR at least catches that and adds a warning message for the user.

Ideally we'd catch outliers and data issues upstream. I feel that's important but can come in a second PR (or multiple PRs). It requires research.