### PR TITLE
Bandaid: Ending Iterative Denoiser based on decreasing negentropy

### DIFF
--- a/meteor/iterative.py
+++ b/meteor/iterative.py
@@ -179,12 +179,12 @@ class IterativeTvDenoiser:
             denoised_difference_sfs, tv_metadata = self._tv_denoise_complex_difference_sf(
                 difference, cell=cell, spacegroup=spacegroup
             )
-            previous_negentropy = metadata[-1].negentropy_after_tv
-            decreasing_negentropy = previous_negentropy > tv_metadata.optimal_negentropy
-            if num_iterations > 1 and decreasing_negentropy:
-                if self.verbose:
-                    log.info("Negentropy decreased after TV step; stopping...")
-                break
+            if num_iterations > 1:
+                previous_negentropy = metadata[-1].negentropy_after_tv
+                if previous_negentropy > tv_metadata.optimal_negentropy:
+                    if self.verbose:
+                        log.info("Negentropy decreased after TV step; stopping...")
+                    break
 
             # project onto the native amplitudes to obtain an "updated_derivative"
             #   Fh' = (D_F' + F) * [|Fh| / |D_F' + F|]

--- a/meteor/iterative.py
+++ b/meteor/iterative.py
@@ -179,6 +179,12 @@ class IterativeTvDenoiser:
             denoised_difference_sfs, tv_metadata = self._tv_denoise_complex_difference_sf(
                 difference, cell=cell, spacegroup=spacegroup
             )
+            previous_negentropy = metadata[-1].negentropy_after_tv
+            decreasing_negentropy = previous_negentropy > tv_metadata.optimal_negentropy
+            if num_iterations > 1 and decreasing_negentropy:
+                if self.verbose:
+                    log.info("Negentropy decreased after TV step; stopping...")
+                break
 
             # project onto the native amplitudes to obtain an "updated_derivative"
             #   Fh' = (D_F' + F) * [|Fh| / |D_F' + F|]
@@ -214,8 +220,9 @@ class IterativeTvDenoiser:
                 )
 
             if num_iterations > self.max_iterations:
+                if self.verbose:
+                    log.info("Maximum number of iterations reached; stopping...")
                 break
-
         return derivative, metadata
 
     def __call__(

--- a/meteor/iterative.py
+++ b/meteor/iterative.py
@@ -219,7 +219,7 @@ class IterativeTvDenoiser:
                     tv_weight=tv_metadata.optimal_parameter_value,
                 )
 
-            if num_iterations > self.max_iterations:
+            if num_iterations >= self.max_iterations:
                 if self.verbose:
                     log.info("Maximum number of iterations reached; stopping...")
                 break

--- a/meteor/utils.py
+++ b/meteor/utils.py
@@ -44,6 +44,7 @@ def filter_common_indices(df1: rs.DataSet, df2: rs.DataSet) -> tuple[rs.DataSet,
         raise IndexError(msg)
     return df1_common, df2_common
 
+
 @overload
 def cut_resolution(
     dataset: Map,
@@ -52,6 +53,7 @@ def cut_resolution(
     high_resolution_limit: float | None = None,
 ) -> Map: ...
 
+
 @overload
 def cut_resolution(
     dataset: rs.DataSet,
@@ -59,7 +61,6 @@ def cut_resolution(
     low_resolution_limit: float | None = None,
     high_resolution_limit: float | None = None,
 ) -> rs.DataSet: ...
-
 
 
 def cut_resolution(

--- a/test/unit/test_iterative.py
+++ b/test/unit/test_iterative.py
@@ -76,6 +76,55 @@ def test_iteratively_denoise_sf_amplitudes_smoke(
     assert isinstance(metadata[0], TvIterationMetadata)
 
 
+def test_iterative_tv_halts_on_decreasing_negentropy(
+    testing_denoiser: IterativeTvDenoiser,
+    random_difference_map: Map,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scripted_negentropies = [1.0, 2.0, 1.5]
+    call_count = {"n": 0}
+
+    def mock_tv_step(
+        complex_difference_sf: rs.DataSeries, *, cell: object, spacegroup: object
+    ) -> tuple[rs.DataSeries, TvScanMetadata]:
+        idx = call_count["n"]
+        call_count["n"] += 1
+        if idx >= len(scripted_negentropies):
+            msg = (
+                f"algorithm did not halt: called {idx + 1} times, "
+                f"only {len(scripted_negentropies)} negentropies scripted"
+            )
+            raise AssertionError(msg)
+        meta = TvScanMetadata(
+            initial_negentropy=0.0,
+            optimal_parameter_value=0.1,
+            optimal_negentropy=scripted_negentropies[idx],
+            map_sampling=5.0,
+            parameter_scan_results=[],
+        )
+        # return the input unchanged so the rest of the loop's arithmetic stays valid
+        return complex_difference_sf.copy(), meta
+
+    monkeypatch.setattr(testing_denoiser, "_tv_denoise_complex_difference_sf", mock_tv_step)
+    # neither convergence nor max_iterations should be the reason we stop
+    testing_denoiser.convergence_tolerance = -1.0
+    testing_denoiser.max_iterations = 1000
+
+    sfs = random_difference_map.to_structurefactor()
+    _, metadata = testing_denoiser._iteratively_denoise_sf_amplitudes(
+        initial_derivative=sfs,
+        native=sfs + 1.0,
+        cell=random_difference_map.cell,
+        spacegroup=random_difference_map.spacegroup,
+    )
+
+    # the third call is the one with decreasing negentropy and should trigger break
+    # before the iteration body runs, so only two iterations get recorded in metadata
+    assert call_count["n"] == 3
+    assert len(metadata) == 2
+    assert [m.negentropy_after_tv for m in metadata] == [1.0, 2.0]
+
+
 def test_iterative_tv_denoiser_different_indices(
     noise_free_map: Map, very_noisy_map: Map, testing_denoiser: IterativeTvDenoiser
 ) -> None:


### PR DESCRIPTION
To adress the issue in #147, I propose adding a breaking condition for the loop for falling negentropy.

I also made the verbose setting minimally more verbose. 

Also, while working on this loop: 
Is it intentional to go 1 run over the loop condition i.e. stopping after 101 if max_iteration = 100?
Proposed fix: moving the iterations break to the top rather than bottom. 