### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly update schedules for `pip` (driven by `pyproject.toml`) and `github-actions` (workflows under `.github/workflows/`).

## Test plan
- [ ] Confirm Dependabot picks up the config and opens its first batch of PRs on the next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)