### PR TITLE
test fail on OSX - numerical stability

### DIFF
--- a/test/unit/test_testing.py
+++ b/test/unit/test_testing.py
@@ -28,7 +28,7 @@ def test_phases_allclose() -> None:
 
 
 def test_map_corrcoeff(noise_free_map: Map, np_rng: np.random.Generator) -> None:
-    assert meteortesting.map_corrcoeff(noise_free_map, noise_free_map) == 1.0
+    assert meteortesting.map_corrcoeff(noise_free_map, noise_free_map) > 0.999
 
     noisy_map = noise_free_map.copy()
     noisy_map.amplitudes += np_rng.normal(size=len(noise_free_map))


### PR DESCRIPTION
For some reason, the OSX tests are failing because `assert meteortesting.map_corrcoeff(noise_free_map, noise_free_map)` returns `0.9999999999999999`, not exactly `1.0`. Some kind of precision issue perhaps.

I did not investigate further, as it seems fine to simply reduce the test strictness.