### PR TITLE
fix for #158

### DIFF
--- a/meteor/rsmap.py
+++ b/meteor/rsmap.py
@@ -251,8 +251,8 @@ class Map(rs.DataSet):
 
     def copy(self, *, deep: bool = True) -> Map:
         new_map = super().copy(deep=deep)
-        new_map._cell = gemmi.UnitCell(*self.cell.parameters)
-        new_map._spacegroup = gemmi.SpaceGroup(self.spacegroup.xhm())
+        new_map.cell = self.cell.parameters
+        new_map.spacegroup = self.spacegroup.xhm()
         return new_map
 
     def get_hkls(self) -> np.ndarray:

--- a/meteor/rsmap.py
+++ b/meteor/rsmap.py
@@ -249,6 +249,12 @@ class Map(rs.DataSet):
     def drop(self, labels: Any, *, inplace: bool = False) -> None | Map:
         return super().drop(labels=labels, axis="index", columns=None, inplace=inplace)
 
+    def copy(self, *, deep: bool = True) -> Map:
+        new_map = super().copy(deep=deep)
+        new_map._cell = gemmi.UnitCell(*self.cell.parameters)
+        new_map._spacegroup = gemmi.SpaceGroup(self.spacegroup.xhm())
+        return new_map
+
     def get_hkls(self) -> np.ndarray:
         # overwrite rs implt'n, return w/o modifying self -> same behavior, under testing - @tjlane
         # this is a rather horrible thing to do and we should fix it

--- a/test/unit/scripts/test_common.py
+++ b/test/unit/scripts/test_common.py
@@ -43,7 +43,9 @@ def test_diffmap_set_scale(random_difference_map: Map, use_uncertainties: bool) 
     diffmap_set = DiffMapSet(
         native=random_difference_map.copy(),
         derivative=random_difference_map.copy(),
-        calculated=random_difference_map.copy() * 2.0,
+        # `Map * float` yields a `Map` at runtime, but mypy cannot see through the
+        # inherited pandas `__mul__`, so the scalar-multiply result is annotated away
+        calculated=random_difference_map.copy() * 2.0,  # type: ignore[arg-type]
     )
 
     # upon scale, both native and derivative should also become 2x bigger

--- a/test/unit/test_rsmap.py
+++ b/test/unit/test_rsmap.py
@@ -109,6 +109,29 @@ def test_copy_non_standard_names(noise_free_map: Map) -> None:
     pd.testing.assert_frame_equal(copy_map, non_std_map)
 
 
+def test_copy_cell_is_independent(noise_free_map: Map) -> None:
+    # regression test for GH#158: Map.copy() must not share `cell` with the original
+    copy_map = noise_free_map.copy()
+    assert copy_map.cell is not noise_free_map.cell
+
+    original_parameters = noise_free_map.cell.parameters
+    copy_map.cell = (1.0, 2.0, 3.0, 90.0, 90.0, 90.0)
+    assert noise_free_map.cell.parameters == original_parameters
+    assert copy_map.cell.parameters != original_parameters
+
+
+def test_copy_spacegroup_is_independent(noise_free_map: Map) -> None:
+    # regression test for GH#158: Map.copy() must not share `spacegroup` with the original
+    copy_map = noise_free_map.copy()
+
+    # `SpaceGroup` objects as immutable singletons, so an identity check is not meaningful here
+    original_number = noise_free_map.spacegroup.number
+    new_number = 19 if original_number != 19 else 1
+    copy_map.spacegroup = new_number
+    assert noise_free_map.spacegroup.number == original_number
+    assert copy_map.spacegroup.number == new_number
+
+
 def test_filter_common_indices_with_maps(noise_free_map: Map) -> None:
     m1 = noise_free_map
     m2 = noise_free_map.copy()


### PR DESCRIPTION
This PR ensures that `Map.copy()` propagates through and copies the `.spacegroup` and `.cell` attributes as well.