### PR TITLE
improved scaling error reporting and robustness

### DIFF
--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -23,6 +23,8 @@ DIMENSION_OF_MILLER_INDEX: int = 3
 
 class ParameterLengthMismatchError(ValueError): ...
 
+class ScalingError(RuntimeError): ...
+
 
 class ScaleMode(StrEnum):
     anisotropic = "anisotropic"
@@ -88,7 +90,7 @@ def compute_scale_factors(
 
     else:
         msg = f"mode {scale_mode} not valid"
-        raise ValueError(msg)
+        raise ScalingError(msg)
 
     # the einsum implements sum_i{ h^T . B . h }
     exponential_argument = -np.einsum("ni,ij,nj->n", vector_h, matrix_B, vector_h)
@@ -98,7 +100,7 @@ def compute_scale_factors(
     if not len(scale_factors) == miller_indices.shape[0]:
         msg = "`scale_factors` and `miller_indices` do not have the same lenghts!"
         msg += f"{len(scale_factors)} vs {miller_indices.shape}"
-        raise RuntimeError(msg)
+        raise ScalingError(msg)
 
     return scale_factors
 
@@ -195,13 +197,13 @@ def scale_maps(
             msg = "Scaling procedure failed -- optimization produced non finite values. "
             msg += "This can be caused by unusual input values. "
             msg += "Recommend: check the input data for severe outliers or issues."
-            raise RuntimeError(msg)
+            raise ScalingError(msg)
         
         if not len(scale_factors) == len(map_to_scale.amplitudes):
             msg = "Scaling procedure failed -- `scale_factors` and `map_to_scale` do not have the "
             msg += "same length. This can be caused by unusual input values. "
             msg += "Recommend: check the input data for severe outliers or issues."
-            raise RuntimeError(msg)
+            raise ScalingError(msg)
 
         difference_after_scaling = (
             scale_factors * map_to_scale.amplitudes - reference_map.amplitudes
@@ -221,7 +223,7 @@ def scale_maps(
     if not np.isfinite(initial_c) or initial_c < 0.0:
         msg = f"`initial_c` is {initial_c}: either not finite or negative. "
         msg += "Check input for errors and outliers"
-        raise RuntimeError(msg)
+        raise ScalingError(msg)
 
     initial_scaling_parameters: ScaleParameters = (initial_c,) + (0.0,) * (
         scale_mode.number_of_parameters - 1
@@ -242,7 +244,7 @@ def scale_maps(
     if len(optimized_scale_factors) != len(unmodified_map_to_scale.index):
         msg1 = "length mismatch: `optimized_scale_factors` - something went wrong"
         msg2 = f"({len(optimized_scale_factors)}) vs `values_to_scale` ({len(unmodified_map_to_scale.index)})"
-        raise RuntimeError(msg1, msg2)
+        raise ScalingError(msg1, msg2)
 
     scaled_map = unmodified_map_to_scale.copy()
     scaled_map.amplitudes *= optimized_scale_factors

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -19,9 +19,12 @@ ScaleParameters = tuple[float, ...]
 log = structlog.get_logger()
 
 DIMENSION_OF_MILLER_INDEX: int = 3
+_MAX_EXPONENT: float = 700.0  # exp(700) ~ 1e304
+_NON_FINITE_RESIDUAL_PENALTY: float = 1e30
 
 
 class ParameterLengthMismatchError(ValueError): ...
+
 
 class ScalingError(RuntimeError): ...
 
@@ -45,26 +48,48 @@ class ScaleMode(StrEnum):
         raise NotImplementedError
 
 
-def compute_scale_factors(
-    *, miller_indices: pd.Index, scale_parameters: ScaleParameters, scale_mode: str | ScaleMode
-) -> np.ndarray:
-    if isinstance(scale_mode, str):
-        scale_mode = ScaleMode(scale_mode)
-
-    vector_h = np.array(list(miller_indices))
-    if vector_h.shape[1] != DIMENSION_OF_MILLER_INDEX:
+def _cast_to_miller_array(miller_indices: pd.Index | np.ndarray) -> np.ndarray:
+    """Coerce a pd.MultiIndex or a precomputed (n, 3) array to an (n, 3) ndarray."""
+    if isinstance(miller_indices, np.ndarray):
+        vector_h = miller_indices
+    else:
+        vector_h = np.array(list(miller_indices))
+    if vector_h.ndim != 2 or vector_h.shape[1] != DIMENSION_OF_MILLER_INDEX:  # noqa: PLR2004
         msg = "`miller_indices` should be an (n, 3) multi-index of miller HKL indices, "
         msg += f"got shape: {vector_h.shape}"
         raise ValueError(msg)
+    return vector_h
 
-    sp_as_array = np.array(scale_parameters)
+
+def compute_scale_factors(
+    *,
+    miller_indices: pd.Index | np.ndarray,
+    scale_parameters: ScaleParameters,
+    scale_mode: str | ScaleMode,
+) -> np.ndarray:
+    """Evaluate the anisotropic scale factor `C * exp(-h^T B h)` for each Miller index.
+
+    `miller_indices` may be a `pd.MultiIndex` or a precomputed `(n, 3)` ndarray.
+    The hot path (called once per least-squares iteration) prefers the ndarray
+    form so we don't re-build it on every call.
+    """
+    if isinstance(scale_mode, str):
+        scale_mode = ScaleMode(scale_mode)
+
+    vector_h = _cast_to_miller_array(miller_indices)
+
+    sp_as_array = np.asarray(scale_parameters, dtype=np.float64)
     if sp_as_array.shape != (scale_mode.number_of_parameters,):
         msg = f"`scale_parameters` should be length {scale_mode.number_of_parameters} "
         msg += f"for mode={scale_mode}, got length: {len(scale_parameters)}"
         raise ParameterLengthMismatchError(msg)
 
+    if not np.all(np.isfinite(sp_as_array)):
+        msg = f"`scale_parameters` must all be finite, got: {tuple(scale_parameters)}"
+        raise ScalingError(msg)
+
     # this code is part of a few tight loops; code below is fast and clear
-    matrix_B = np.zeros((3, 3), dtype=sp_as_array.dtype)  # noqa: N806 (variable capitalization)
+    matrix_B = np.zeros((3, 3), dtype=np.float64)  # noqa: N806 (variable capitalization)
 
     if scale_mode == ScaleMode.anisotropic:
         matrix_B[0, 0] = sp_as_array[1]
@@ -88,21 +113,12 @@ def compute_scale_factors(
     elif scale_mode == ScaleMode.scalar:
         return sp_as_array[0] * np.ones(vector_h.shape[0], dtype=np.float64)
 
-    else:
-        msg = f"mode {scale_mode} not valid"
-        raise ScalingError(msg)
-
     # the einsum implements sum_i{ h^T . B . h }
     exponential_argument = -np.einsum("ni,ij,nj->n", vector_h, matrix_B, vector_h)
+    # clip so the optimizer can transiently visit large |B| without producing inf
+    np.clip(exponential_argument, -_MAX_EXPONENT, _MAX_EXPONENT, out=exponential_argument)
 
-    scale_factors = sp_as_array[0] * np.exp(exponential_argument)
-
-    if len(scale_factors) != miller_indices.shape[0]:
-        msg = "`scale_factors` and `miller_indices` do not have the same lenghts!"
-        msg += f"{len(scale_factors)} vs {miller_indices.shape}"
-        raise ScalingError(msg)
-
-    return scale_factors
+    return sp_as_array[0] * np.exp(exponential_argument)
 
 
 def scale_maps(
@@ -111,7 +127,7 @@ def scale_maps(
     map_to_scale: Map,
     scale_mode: ScaleMode = ScaleMode.anisotropic,
     weight_using_uncertainties: bool = True,
-    least_squares_loss: str | Callable = "huber",
+    least_squares_loss: str | Callable[[np.ndarray], np.ndarray] = "huber",
 ) -> Map:
     """
     Scale a dataset to align it with a reference dataset using anisotropic scaling.
@@ -174,55 +190,61 @@ def scale_maps(
     unmodified_map_to_scale = map_to_scale.copy()
     reference_map, map_to_scale = filter_common_indices(reference_map, map_to_scale)
 
-    one = np.array(1.0)  # a constant if there are no uncertainties to use
-    ref_variance: np.ndarray = (
-        np.square(reference_map.uncertainties)
-        if (reference_map.has_uncertainties and weight_using_uncertainties)
-        else one
+    ref_amps = np.asarray(reference_map.amplitudes, dtype=np.float64)
+    to_amps = np.asarray(map_to_scale.amplitudes, dtype=np.float64)
+
+    use_ref_sigmas = reference_map.has_uncertainties and weight_using_uncertainties
+    use_to_sigmas = map_to_scale.has_uncertainties and weight_using_uncertainties
+    ref_sigmas = (
+        np.asarray(reference_map.uncertainties, dtype=np.float64) if use_ref_sigmas else None
     )
-    to_scale_variance: np.ndarray = (
-        np.square(map_to_scale.uncertainties)
-        if (map_to_scale.has_uncertainties and weight_using_uncertainties)
-        else one
+    to_sigmas = (
+        np.asarray(map_to_scale.uncertainties, dtype=np.float64) if use_to_sigmas else None
     )
-    sqrt_inverse_variance = 1.0 / np.sqrt(ref_variance + to_scale_variance)
+
+    valid = np.isfinite(ref_amps) & np.isfinite(to_amps)
+    if ref_sigmas is not None:
+        valid &= np.isfinite(ref_sigmas) & (ref_sigmas > 0.0)
+    if to_sigmas is not None:
+        valid &= np.isfinite(to_sigmas) & (to_sigmas > 0.0)
+
+    n_valid = int(valid.sum())
+    if n_valid == 0:
+        msg = (
+            "No finite common reflections to fit. "
+            "Check input maps for missing values or invalid uncertainties."
+        )
+        raise ScalingError(msg)
+
+    ref_amps = ref_amps[valid]
+    to_amps = to_amps[valid]
+    ref_variance: np.ndarray | float = ref_sigmas[valid] ** 2 if ref_sigmas is not None else 1.0
+    to_variance: np.ndarray | float = to_sigmas[valid] ** 2 if to_sigmas is not None else 1.0
+    sqrt_inverse_variance = 1.0 / np.sqrt(ref_variance + to_variance)
+
+    miller_array = _cast_to_miller_array(reference_map.index)[valid]
 
     def compute_residuals(scale_parameters: ScaleParameters) -> np.ndarray:
         scale_factors = compute_scale_factors(
-            miller_indices=reference_map.index,
+            miller_indices=miller_array,
             scale_parameters=scale_parameters,
             scale_mode=scale_mode,
         )
-        if not np.all(np.isfinite(scale_factors)):
-            msg = "Scaling procedure failed -- optimization produced non finite values. "
-            msg += "This can be caused by unusual input values. "
-            msg += "Recommend: check the input data for severe outliers or issues."
-            raise ScalingError(msg)
+        residuals = sqrt_inverse_variance * (scale_factors * to_amps - ref_amps)
 
-        if len(scale_factors) != len(map_to_scale.amplitudes):
-            msg = "Scaling procedure failed -- `scale_factors` and `map_to_scale` do not have the "
-            msg += "same length. This can be caused by unusual input values. "
-            msg += "Recommend: check the input data for severe outliers or issues."
-            raise ScalingError(msg)
-
-        difference_after_scaling = (
-            scale_factors * map_to_scale.amplitudes - reference_map.amplitudes
+        return np.nan_to_num(
+            residuals,
+            nan=_NON_FINITE_RESIDUAL_PENALTY,
+            posinf=_NON_FINITE_RESIDUAL_PENALTY,
+            neginf=-_NON_FINITE_RESIDUAL_PENALTY,
         )
-        residuals = np.array(sqrt_inverse_variance * difference_after_scaling, dtype=np.float64)
 
-        # filter NaNs in input -- are simply missing values
-        residuals = residuals[np.isfinite(residuals)]
-
-        if not isinstance(residuals, np.ndarray):
-            msg = "scipy optimizers' behavior is unstable unless `np.ndarray`s are used"
-            raise TypeError(msg)
-
-        return residuals
-
-    initial_c = float(np.mean(reference_map.amplitudes) / np.mean(map_to_scale.amplitudes))
+    initial_c = float(ref_amps.mean() / to_amps.mean())
     if not np.isfinite(initial_c) or initial_c < 0.0:
-        msg = f"`initial_c` is {initial_c}: either not finite or negative. "
-        msg += "Check input for errors and outliers"
+        msg = (
+            f"`initial_c` is {initial_c}: either not finite or negative. "
+            "Check input for errors and outliers"
+        )
         raise ScalingError(msg)
 
     initial_scaling_parameters: ScaleParameters = (initial_c,) + (0.0,) * (
@@ -233,18 +255,13 @@ def scale_maps(
         initial_scaling_parameters,
         loss=least_squares_loss,
     )
-    optimized_parameters: ScaleParameters = optimization_result.x
+    optimized_parameters: ScaleParameters = tuple(optimization_result.x)
 
     optimized_scale_factors = compute_scale_factors(
         miller_indices=unmodified_map_to_scale.index,
         scale_parameters=optimized_parameters,
         scale_mode=scale_mode,
     )
-
-    if len(optimized_scale_factors) != len(unmodified_map_to_scale.index):
-        msg1 = "length mismatch: `optimized_scale_factors` - something went wrong"
-        msg2 = f"({len(optimized_scale_factors)}) vs `values_to_scale` ({len(unmodified_map_to_scale.index)})"
-        raise ScalingError(msg1, msg2)
 
     scaled_map = unmodified_map_to_scale.copy()
     scaled_map.amplitudes *= optimized_scale_factors

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -19,8 +19,9 @@ ScaleParameters = tuple[float, ...]
 log = structlog.get_logger()
 
 DIMENSION_OF_MILLER_INDEX: int = 3
-_MAX_SCALE_FACTOR: float = 1e300
-_NON_FINITE_RESIDUAL_PENALTY: float = 1e30
+MAX_SCALE_FACTOR: float = 1e300
+NON_FINITE_RESIDUAL_PENALTY: float = 1e30
+MIN_FRACTION_COMMON_INDICES: float = 0.5
 
 
 class ParameterLengthMismatchError(ValueError): ...
@@ -117,7 +118,7 @@ def compute_scale_factors(
     exponential_argument = -np.einsum("ni,ij,nj->n", vector_h, matrix_B, vector_h)
 
     scale_factors = sp_as_array[0] * np.exp(exponential_argument)
-    return np.clip(scale_factors, -_MAX_SCALE_FACTOR, _MAX_SCALE_FACTOR)
+    return np.clip(scale_factors, -MAX_SCALE_FACTOR, MAX_SCALE_FACTOR)
 
 
 def scale_maps(
@@ -197,9 +198,7 @@ def scale_maps(
     ref_sigmas = (
         np.asarray(reference_map.uncertainties, dtype=np.float64) if use_ref_sigmas else None
     )
-    to_sigmas = (
-        np.asarray(map_to_scale.uncertainties, dtype=np.float64) if use_to_sigmas else None
-    )
+    to_sigmas = np.asarray(map_to_scale.uncertainties, dtype=np.float64) if use_to_sigmas else None
 
     valid = np.isfinite(ref_amps) & np.isfinite(to_amps)
     if ref_sigmas is not None:
@@ -214,6 +213,13 @@ def scale_maps(
             "Check input maps for missing values or invalid uncertainties."
         )
         raise ScalingError(msg)
+
+    fraction_common_indices = float(n_valid / len(valid))
+    if fraction_common_indices < MIN_FRACTION_COMMON_INDICES:
+        log.warning(
+            "very small number of common indices between datasets to be scaled together",
+            fraction_common_indices=fraction_common_indices,
+        )
 
     ref_amps = ref_amps[valid]
     to_amps = to_amps[valid]
@@ -233,9 +239,9 @@ def scale_maps(
 
         return np.nan_to_num(
             residuals,
-            nan=_NON_FINITE_RESIDUAL_PENALTY,
-            posinf=_NON_FINITE_RESIDUAL_PENALTY,
-            neginf=-_NON_FINITE_RESIDUAL_PENALTY,
+            nan=NON_FINITE_RESIDUAL_PENALTY,
+            posinf=NON_FINITE_RESIDUAL_PENALTY,
+            neginf=-NON_FINITE_RESIDUAL_PENALTY,
         )
 
     initial_c = float(ref_amps.mean() / to_amps.mean())

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -19,7 +19,7 @@ ScaleParameters = tuple[float, ...]
 log = structlog.get_logger()
 
 DIMENSION_OF_MILLER_INDEX: int = 3
-_MAX_EXPONENT: float = 700.0  # exp(700) ~ 1e304
+_MAX_SCALE_FACTOR: float = 1e300
 _NON_FINITE_RESIDUAL_PENALTY: float = 1e30
 
 
@@ -115,10 +115,9 @@ def compute_scale_factors(
 
     # the einsum implements sum_i{ h^T . B . h }
     exponential_argument = -np.einsum("ni,ij,nj->n", vector_h, matrix_B, vector_h)
-    # clip so the optimizer can transiently visit large |B| without producing inf
-    np.clip(exponential_argument, -_MAX_EXPONENT, _MAX_EXPONENT, out=exponential_argument)
 
-    return sp_as_array[0] * np.exp(exponential_argument)
+    scale_factors = sp_as_array[0] * np.exp(exponential_argument)
+    return np.clip(scale_factors, -_MAX_SCALE_FACTOR, _MAX_SCALE_FACTOR)
 
 
 def scale_maps(

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -93,7 +93,14 @@ def compute_scale_factors(
     # the einsum implements sum_i{ h^T . B . h }
     exponential_argument = -np.einsum("ni,ij,nj->n", vector_h, matrix_B, vector_h)
 
-    return sp_as_array[0] * np.exp(exponential_argument)
+    scale_factors = sp_as_array[0] * np.exp(exponential_argument)
+
+    if not len(scale_factors) == miller_indices.shape[0]:
+        msg = "`scale_factors` and `miller_indices` do not have the same lenghts!"
+        msg += f"{len(scale_factors)} vs {miller_indices.shape}"
+        raise RuntimeError(msg)
+
+    return scale_factors
 
 
 def scale_maps(
@@ -187,7 +194,13 @@ def scale_maps(
         if not np.all(np.isfinite(scale_factors)):
             msg = "Scaling procedure failed -- optimization produced non finite values. "
             msg += "This can be caused by unusual input values. "
-            msg += "Recommend: check the input data for severe outliers."
+            msg += "Recommend: check the input data for severe outliers or issues."
+            raise RuntimeError(msg)
+        
+        if not len(scale_factors) == len(map_to_scale.amplitudes):
+            msg = "Scaling procedure failed -- `scale_factors` and `map_to_scale` do not have the "
+            msg += "same length. This can be caused by unusual input values. "
+            msg += "Recommend: check the input data for severe outliers or issues."
             raise RuntimeError(msg)
 
         difference_after_scaling = (

--- a/meteor/scale.py
+++ b/meteor/scale.py
@@ -97,7 +97,7 @@ def compute_scale_factors(
 
     scale_factors = sp_as_array[0] * np.exp(exponential_argument)
 
-    if not len(scale_factors) == miller_indices.shape[0]:
+    if len(scale_factors) != miller_indices.shape[0]:
         msg = "`scale_factors` and `miller_indices` do not have the same lenghts!"
         msg += f"{len(scale_factors)} vs {miller_indices.shape}"
         raise ScalingError(msg)
@@ -198,8 +198,8 @@ def scale_maps(
             msg += "This can be caused by unusual input values. "
             msg += "Recommend: check the input data for severe outliers or issues."
             raise ScalingError(msg)
-        
-        if not len(scale_factors) == len(map_to_scale.amplitudes):
+
+        if len(scale_factors) != len(map_to_scale.amplitudes):
             msg = "Scaling procedure failed -- `scale_factors` and `map_to_scale` do not have the "
             msg += "same length. This can be caused by unusual input values. "
             msg += "Recommend: check the input data for severe outliers or issues."

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from unittest.mock import patch
 
 import gemmi
 import numpy as np
@@ -354,55 +353,100 @@ def test_scale_maps_large_mismatch_protein_cell(scale_mode: ScaleMode) -> None:
     np.testing.assert_allclose(scaled.amplitudes, reference_map.amplitudes, rtol=1e-3)
 
 
-def test_scale_maps_raises_on_non_finite_scale_factors(random_difference_map: Map) -> None:
-    with patch("meteor.scale.compute_scale_factors") as mock_compute_scale_factors:
-        mock_scale_factors = np.ones(len(random_difference_map))
-        mock_scale_factors[0] = np.inf  # Insert a non-finite value
-        mock_compute_scale_factors.return_value = mock_scale_factors
-
-        with pytest.raises(
-            ScalingError,
-            match="Scaling procedure failed -- optimization produced non finite values",
-        ):
-            scale.scale_maps(
-                reference_map=random_difference_map,
-                map_to_scale=random_difference_map,
-            )
-
-
-def test_scale_maps_raises_on_scale_factor_length_mismatch(random_difference_map: Map) -> None:
-    with patch("meteor.scale.compute_scale_factors") as mock_compute_scale_factors:
-        mock_compute_scale_factors.return_value = np.ones(len(random_difference_map) - 1)
-
-        with pytest.raises(
-            ScalingError,
-            match=r"`scale_factors` and `map_to_scale` do not have the same length",
-        ):
-            scale.scale_maps(
-                reference_map=random_difference_map,
-                map_to_scale=random_difference_map,
-            )
+@pytest.mark.parametrize("scale_mode", ScaleMode)
+def test_compute_scale_factors_clips_overflow(
+    scale_mode: ScaleMode, miller_dataseries: rs.DataSeries
+) -> None:
+    # Pre-clip insurance: pathological B parameters used to overflow `exp(-h^T B h)`
+    # to +inf and poison the residual vector. The clip in compute_scale_factors keeps
+    # the output finite for every mode that uses the exponent.
+    huge_b = 1e6
+    params = (1.0,) + (huge_b,) * (scale_mode.number_of_parameters - 1)
+    out = compute_scale_factors(
+        miller_indices=miller_dataseries.index,
+        scale_parameters=params,
+        scale_mode=scale_mode,
+    )
+    assert np.all(np.isfinite(out))
 
 
-def test_compute_scale_factors_raises_on_internal_length_mismatch(
+@pytest.mark.parametrize("bad_value", [np.nan, np.inf, -np.inf])
+def test_compute_scale_factors_rejects_non_finite_parameters(
+    miller_dataseries: rs.DataSeries, bad_value: float
+) -> None:
+    params = (1.0, bad_value, 0.0, 0.0, 0.0, 0.0, 0.0)
+    with pytest.raises(ScalingError, match=r"`scale_parameters` must all be finite"):
+        _ = compute_scale_factors(
+            miller_indices=miller_dataseries.index,
+            scale_parameters=params,
+            scale_mode=ScaleMode.anisotropic,
+        )
+
+
+def test_compute_scale_factors_accepts_ndarray_miller_indices(
     miller_dataseries: rs.DataSeries,
 ) -> None:
-    scale_mode = ScaleMode.anisotropic
-    arbitrary_params = (1.0,) * scale_mode.number_of_parameters
-    short_exponent = np.zeros(len(miller_dataseries) - 1)
+    # The hot path inside `scale_maps` passes a precomputed (n, 3) ndarray instead of
+    # a pd.Index. Verify the array form gives the same answer as the Index form.
+    params = (1.5, 0.01, 0.02, 0.03, 0.0, 0.0, 0.0)
+    miller_arr = np.asarray(list(miller_dataseries.index))
 
-    with (
-        patch("meteor.scale.np.einsum", return_value=short_exponent),
-        pytest.raises(
-            ScalingError,
-            match=r"`scale_factors` and `miller_indices` do not have the same",
-        ),
-    ):
-            _ = compute_scale_factors(
-                miller_indices=miller_dataseries.index,
-                scale_parameters=arbitrary_params,
-                scale_mode=scale_mode,
-            )
+    from_index = compute_scale_factors(
+        miller_indices=miller_dataseries.index,
+        scale_parameters=params,
+        scale_mode=ScaleMode.anisotropic,
+    )
+    from_array = compute_scale_factors(
+        miller_indices=miller_arr,
+        scale_parameters=params,
+        scale_mode=ScaleMode.anisotropic,
+    )
+    np.testing.assert_array_equal(from_index, from_array)
+
+
+def test_scale_maps_raises_when_no_finite_common_reflections(random_difference_map: Map) -> None:
+    # If every common reflection is NaN we cannot fit anything; should raise a clear
+    # ScalingError up front instead of letting scipy fail mysteriously.
+    all_nan = random_difference_map.copy()
+    all_nan.amplitudes *= np.nan
+
+    with pytest.raises(ScalingError, match=r"No finite common reflections"):
+        scale.scale_maps(
+            reference_map=random_difference_map,
+            map_to_scale=all_nan,
+        )
+
+
+def test_scale_maps_recovers_scale_with_partial_nan_inputs(random_difference_map: Map) -> None:
+    # Regression test for #162: dropping reflections via NaN must not change the
+    # residual vector length seen by scipy across iterations. Inject NaNs into a
+    # subset of `map_to_scale` and confirm the recovered scale matches a clean fit.
+    multiple = 3.0
+    reference = random_difference_map.copy()
+    reference.amplitudes = np.abs(reference.amplitudes) + 1.0
+
+    scaled_clean = reference.copy()
+    scaled_clean.amplitudes = scaled_clean.amplitudes / multiple
+
+    scaled_with_nans = scaled_clean.copy()
+    nan_rows = np.zeros(len(scaled_with_nans), dtype=bool)
+    nan_rows[::7] = True  # ~14% of reflections marked missing
+    scaled_with_nans.loc[nan_rows, scaled_with_nans.amplitudes.name] = np.nan
+
+    recovered = scale.scale_maps(
+        reference_map=reference,
+        map_to_scale=scaled_with_nans,
+        scale_mode=ScaleMode.scalar,
+        least_squares_loss="linear",
+    )
+
+    # the finite entries should be recovered to within numerical tolerance
+    finite = np.isfinite(np.asarray(recovered.amplitudes, dtype=np.float64))
+    np.testing.assert_allclose(
+        np.asarray(recovered.amplitudes, dtype=np.float64)[finite],
+        np.asarray(reference.amplitudes, dtype=np.float64)[finite],
+        rtol=1e-4,
+    )
 
 
 def test_scale_maps_raises_on_non_finite_initial_c(random_difference_map: Map) -> None:

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -391,11 +391,13 @@ def test_compute_scale_factors_raises_on_internal_length_mismatch(
     arbitrary_params = (1.0,) * scale_mode.number_of_parameters
     short_exponent = np.zeros(len(miller_dataseries) - 1)
 
-    with patch("meteor.scale.np.einsum", return_value=short_exponent):
-        with pytest.raises(
+    with (
+        patch("meteor.scale.np.einsum", return_value=short_exponent),
+        pytest.raises(
             ScalingError,
             match=r"`scale_factors` and `miller_indices` do not have the same",
-        ):
+        ),
+    ):
             _ = compute_scale_factors(
                 miller_indices=miller_dataseries.index,
                 scale_parameters=arbitrary_params,

--- a/test/unit/test_scale.py
+++ b/test/unit/test_scale.py
@@ -13,6 +13,7 @@ from meteor.scale import (
     ParameterLengthMismatchError,
     ScaleMode,
     ScaleParameters,
+    ScalingError,
     compute_scale_factors,
 )
 
@@ -360,13 +361,70 @@ def test_scale_maps_raises_on_non_finite_scale_factors(random_difference_map: Ma
         mock_compute_scale_factors.return_value = mock_scale_factors
 
         with pytest.raises(
-            RuntimeError,
+            ScalingError,
             match="Scaling procedure failed -- optimization produced non finite values",
         ):
             scale.scale_maps(
                 reference_map=random_difference_map,
                 map_to_scale=random_difference_map,
             )
+
+
+def test_scale_maps_raises_on_scale_factor_length_mismatch(random_difference_map: Map) -> None:
+    with patch("meteor.scale.compute_scale_factors") as mock_compute_scale_factors:
+        mock_compute_scale_factors.return_value = np.ones(len(random_difference_map) - 1)
+
+        with pytest.raises(
+            ScalingError,
+            match=r"`scale_factors` and `map_to_scale` do not have the same length",
+        ):
+            scale.scale_maps(
+                reference_map=random_difference_map,
+                map_to_scale=random_difference_map,
+            )
+
+
+def test_compute_scale_factors_raises_on_internal_length_mismatch(
+    miller_dataseries: rs.DataSeries,
+) -> None:
+    scale_mode = ScaleMode.anisotropic
+    arbitrary_params = (1.0,) * scale_mode.number_of_parameters
+    short_exponent = np.zeros(len(miller_dataseries) - 1)
+
+    with patch("meteor.scale.np.einsum", return_value=short_exponent):
+        with pytest.raises(
+            ScalingError,
+            match=r"`scale_factors` and `miller_indices` do not have the same",
+        ):
+            _ = compute_scale_factors(
+                miller_indices=miller_dataseries.index,
+                scale_parameters=arbitrary_params,
+                scale_mode=scale_mode,
+            )
+
+
+def test_scale_maps_raises_on_non_finite_initial_c(random_difference_map: Map) -> None:
+    zeroed = random_difference_map.copy()
+    zeroed.amplitudes *= 0.0
+    with pytest.raises(ScalingError, match=r"`initial_c` is .*: either not finite or negative"):
+        scale.scale_maps(
+            reference_map=random_difference_map,
+            map_to_scale=zeroed,
+        )
+
+
+def test_scale_maps_raises_on_negative_initial_c(random_difference_map: Map) -> None:
+    # Negate `map_to_scale` amplitudes so `initial_c` is negative.
+    negated = random_difference_map.copy()
+    negated.amplitudes = -np.abs(negated.amplitudes) - 1.0
+    reference = random_difference_map.copy()
+    reference.amplitudes = np.abs(reference.amplitudes) + 1.0
+
+    with pytest.raises(ScalingError, match=r"`initial_c` is .*: either not finite or negative"):
+        scale.scale_maps(
+            reference_map=reference,
+            map_to_scale=negated,
+        )
 
 
 @pytest.mark.parametrize("multiple", [0.6, 1.0, 2.3])


### PR DESCRIPTION
Addressing #162 -- scaling can break many ways, current code design is fragile.

There was an issue previously in the code design. NaN values used to mark missing data were sliced out, but this happened after the scaling optimizer ran... if the optimizer went off the rails, it would produce new NaNs, creating chaos when they were sliced out.

This PR refactored some of the code so that slicing missing data happens cleanly before this step, which should be more robust.

I also added safeguards on the optimizer to try and stabilize it.

EDIT: 
### Copilot Summary

This pull request significantly improves the robustness, reliability, and test coverage of the scaling logic in `meteor/scale.py`. The main changes include stricter input validation, better handling of edge cases (such as missing or non-finite data), improved numerical stability, and expanded tests to cover new and existing behaviors. Several new constants and error types are introduced to clarify error handling and make the code easier to maintain.

**Key improvements and changes:**

**1. Robustness and Error Handling**
- Introduced new constants (`MAX_SCALE_FACTOR`, `NON_FINITE_RESIDUAL_PENALTY`, `MIN_FRACTION_COMMON_INDICES`) and a dedicated `ScalingError` exception to handle scaling-specific errors more clearly.
- Added input validation to ensure all scale parameters are finite and raise `ScalingError` if not, preventing silent failures and improving debuggability.
- Improved error messages and checks for cases where there are no valid reflections to scale, or when the initial scaling constant is invalid (non-finite or negative), raising `ScalingError` with descriptive messages.

**2. Numerical Stability**
- Clipped the computed scale factors to a maximum absolute value (`MAX_SCALE_FACTOR`) to prevent numerical overflow and ensure all returned values are finite.
- Used `np.nan_to_num` in residual computation to replace any non-finite values with a large penalty, ensuring optimizers receive stable, finite input.

**3. API and Type Improvements**
- Allowed `compute_scale_factors` to accept either a `pd.Index` or a precomputed `(n, 3)` ndarray for Miller indices, improving performance by avoiding redundant conversions in tight loops.
- Improved type annotations for the `least_squares_loss` parameter to clarify expected callable signatures.

**4. Test Suite Expansion and Modernization**
- Added comprehensive new tests for edge cases, including handling of non-finite parameters, overflow in scale factors, missing data (NaNs), and correct error raising for invalid input.
- Updated tests to use `pytest.mark.parametrize` for systematic coverage of different scale modes and input types.
- Removed unnecessary mocking and legacy code from tests, streamlining the test suite.

**5. Code Quality and Maintainability**
- Refactored internal logic for clarity and efficiency, including extracting a helper function `_cast_to_miller_array` and simplifying array handling throughout.
- Ensured all returned arrays are of consistent type and shape, and removed redundant or unreachable code.

These changes make the scaling functionality more robust, easier to debug, and better tested, reducing the likelihood of silent failures in production and improving maintainability.

- Robustness and Error Handling: [[1]](diffhunk://#diff-61a26a7427dd6659136e0d6aebd9e206b0967c489b82ff610f27be469b221936R22-R32) [[2]](diffhunk://#diff-61a26a7427dd6659136e0d6aebd9e206b0967c489b82ff610f27be469b221936R52-R93) [[3]](diffhunk://#diff-61a26a7427dd6659136e0d6aebd9e206b0967c489b82ff610f27be469b221936L168-R253)
- Numerical Stability: [[1]](diffhunk://#diff-61a26a7427dd6659136e0d6aebd9e206b0967c489b82ff610f27be469b221936L89-R121) [[2]](diffhunk://#diff-61a26a7427dd6659136e0d6aebd9e206b0967c489b82ff610f27be469b221936L168-R253)
- API and Type Improvements: [[1]](diffhunk://#diff-61a26a7427dd6659136e0d6aebd9e206b0967c489b82ff610f27be469b221936R52-R93) [[2]](diffhunk://#diff-61a26a7427dd6659136e0d6aebd9e206b0967c489b82ff610f27be469b221936L105-R130)
- Test Suite Expansion and Modernization: [[1]](diffhunk://#diff-aabbf11104ca7a37bd1a12c51b62fdbaec50a068697cafa69c31742a1fc7d5efL356-R472) [[2]](diffhunk://#diff-aabbf11104ca7a37bd1a12c51b62fdbaec50a068697cafa69c31742a1fc7d5efL2)
- Code Quality and Maintainability: [[1]](diffhunk://#diff-61a26a7427dd6659136e0d6aebd9e206b0967c489b82ff610f27be469b221936R52-R93) [[2]](diffhunk://#diff-61a26a7427dd6659136e0d6aebd9e206b0967c489b82ff610f27be469b221936L221-L233)