### PR TITLE
Preserve amplitude/phase/uncertainty column names across pickle

### DIFF
--- a/meteor/rsmap.py
+++ b/meteor/rsmap.py
@@ -73,6 +73,16 @@ class Map(rs.DataSet):
     # these columns are always allowed
     _allowed_columns: ClassVar[list[str]] = ["H", "K", "L"]
 
+    # without this, pandas drops these attributes on pickle/copy/slicing operations, since they
+    # are not part of `rs.DataSet._metadata` -- see:
+    # https://pandas.pydata.org/docs/development/extending.html#define-original-properties
+    _metadata: ClassVar[list[str]] = [
+        *rs.DataSet._metadata,  # noqa: SLF001, combining parent `_metadata` is the standard pattern
+        "_amplitude_column",
+        "_phase_column",
+        "_uncertainty_column",
+    ]
+
     # in addition, __init__ specifies 3 columns special that can be named dynamically to support:
     # amplitudes, phases, uncertainties; all other columns are forbidden
 

--- a/test/unit/test_rsmap.py
+++ b/test/unit/test_rsmap.py
@@ -1,3 +1,4 @@
+import pickle
 from pathlib import Path
 
 import gemmi
@@ -130,6 +131,22 @@ def test_copy_spacegroup_is_independent(noise_free_map: Map) -> None:
     copy_map.spacegroup = new_number
     assert noise_free_map.spacegroup.number == original_number
     assert copy_map.spacegroup.number == new_number
+
+
+def test_pickle_preserves_column_names(noise_free_map: Map) -> None:
+    # regression test: `_amplitude_column`/`_phase_column`/`_uncertainty_column` must survive a
+    # pickle round-trip (eg. as used by `multiprocessing`), since pandas only preserves instance
+    # attributes declared in `_metadata`
+    pickled_map = pickle.loads(pickle.dumps(noise_free_map))  # noqa: S301, trusted local data
+
+    assert isinstance(pickled_map, Map)
+    assert pickled_map.amplitude_column_name == noise_free_map.amplitude_column_name
+    assert pickled_map.phase_column_name == noise_free_map.phase_column_name
+    assert pickled_map.uncertainties_column_name == noise_free_map.uncertainties_column_name
+    pd.testing.assert_frame_equal(pickled_map, noise_free_map)
+
+    # the methods that read these private attributes should also work after unpickling
+    pickled_map.to_structurefactor()
 
 
 def test_filter_common_indices_with_maps(noise_free_map: Map) -> None:


### PR DESCRIPTION
See #166 

`Map` stored `_amplitude_column`, `_phase_column`, and `_uncertainty_column` as plain instance attributes, which pandas drops on pickle/copy/slicing unless they're declared in `_metadata`. This broke `multiprocessing` (which pickles arguments even with a single worker) and any other pickle-based serialization, causing `AttributeError` deep inside methods like `to_structurefactor()` after a round-trip.